### PR TITLE
Reimplement Platformio commands in Lua to enable arguments completion

### DIFF
--- a/lua/platformio/cmd_cmp.lua
+++ b/lua/platformio/cmd_cmp.lua
@@ -1,7 +1,0 @@
-local M = {}
-
-function M.complete_piorun(arg_lead, cmd_line, cursor_pos)
-	return { "upload", "build", "clean" }
-end
-
-return M

--- a/lua/platformio/cmd_cmp.lua
+++ b/lua/platformio/cmd_cmp.lua
@@ -1,0 +1,7 @@
+local M = {}
+
+function M.complete_piorun(arg_lead, cmd_line, cursor_pos)
+	return { "upload", "build", "clean" }
+end
+
+return M

--- a/plugin/platformio.lua
+++ b/plugin/platformio.lua
@@ -48,4 +48,18 @@ end, {
 	nargs = "+", -- means can take another argument
 })
 
--- TODO:: implement Piodebug and Pioterm
+-- Piocmd
+vim.api.nvim_create_user_command("Piocmd", function(opts)
+	-- Split the args into a table
+	local cmd_table = vim.split(opts.args, " ")
+
+	-- Call the piolib function with the arguments
+	require("platformio.pioterm").piocmd(cmd_table)
+end, {
+	nargs = "+", -- means can take another argument
+})
+
+-- Piodebug
+vim.api.nvim_create_user_command("Piodebug", function()
+	require("platformio.piodb").piodb()
+end, {})

--- a/plugin/platformio.lua
+++ b/plugin/platformio.lua
@@ -4,7 +4,9 @@ vim.api.nvim_create_user_command("Pioinit", function()
 end, {})
 
 -- Piodb
--- vim.api.nvim_create_user_command("Piodb", require("platformio.piodb").piodb(), {})
+vim.api.nvim_create_user_command("Piodb", function()
+	require("platformio.piodb").piodb()
+end, {})
 
 -- Piorun
 vim.api.nvim_create_user_command("Piorun", function(opts)
@@ -25,4 +27,17 @@ end, {
 	end,
 })
 
--- vim.api.nvim_create_user_command("MyFirstFunction", require("plugin_name").hello, {})
+-- Piomon
+vim.api.nvim_create_user_command("Piomon", function(opts)
+	local args = opts.args
+	if args == 0 then
+		require("platformio.piomon").piomon(0)
+	else
+		require("platformio.piomon").piomon(args)
+	end
+end, {})
+
+-- Piolib
+vim.api.nvim_create_user_command("Piolib", function()
+	require("platformio.piolib").piolib()
+end, {})

--- a/plugin/platformio.lua
+++ b/plugin/platformio.lua
@@ -17,8 +17,10 @@ vim.api.nvim_create_user_command("Piorun", function(opts)
 		require("platformio.piorun").piobuild()
 	elseif args == "clean" then
 		require("platformio.piorun").pioclean()
+	elseif args == "uploadfs" then
+		require("platformio.piorun").piouploadfs()
 	else
-		vim.api.nvim_err_writeln("Invalid argument. Use 'upload', 'build', or 'clean'.") -- error message if the cmd is invalid
+		vim.api.nvim_err_writeln("Invalid argument. Use 'upload', 'uploadfs', 'build', or 'clean'.") -- error message if the cmd is invalid
 	end
 end, {
 	nargs = 1, -- Only one argument is expected
@@ -28,14 +30,20 @@ end, {
 })
 
 -- Piomon
+-- https://docs.arduino.cc/learn/communication/uart/ as a base
 vim.api.nvim_create_user_command("Piomon", function(opts)
 	local args = opts.args -- the piomon function will take care of argument error
-	if args == 0 then
-		require("platformio.piomon").piomon(0)
-	else
+	if args ~= 0 then
 		require("platformio.piomon").piomon(args)
+	else
+		vim.api.nvim_err_writeln("Invalid argument or missing argument. Use 'baud rate', example: `:Piomon 115200`")
 	end
-end, {})
+end, {
+	nargs = 1,
+	complete = function(_, _, _)
+		return { 4800, 9600, 57600, 115200 }
+	end,
+})
 
 -- Piolib
 vim.api.nvim_create_user_command("Piolib", function(opts)

--- a/plugin/platformio.lua
+++ b/plugin/platformio.lua
@@ -1,0 +1,13 @@
+vim.api.nvim_create_user_command("Piorun", function(opts)
+	local args = vim.split(opts.args, " ")
+	if vim.tbl_contains({ "upload", "build", "clean" }, args[1]) then
+		require("platformio.piorun").piorun(args)
+	else
+		vim.api.nvim_err_writeln("Invalid argument. Use 'upload', 'build', or 'clean'.")
+	end
+end, {
+	nargs = 1, -- Only one argument is expected
+	complete = function(_, _, _)
+		return { "upload", "build", "clean" } -- Autocompletion options
+	end,
+})

--- a/plugin/platformio.lua
+++ b/plugin/platformio.lua
@@ -1,20 +1,20 @@
 -- Pioinit
-vim.api.nvim_create_user_command(
-  "Pioinit",
-  function()
-    require("platformio.pioinit").pioinit()
-  end,
-  {}
-)
+vim.api.nvim_create_user_command("Pioinit", function()
+	require("platformio.pioinit").pioinit()
+end, {})
 
 -- Piodb
 -- vim.api.nvim_create_user_command("Piodb", require("platformio.piodb").piodb(), {})
 
 -- Piorun
 vim.api.nvim_create_user_command("Piorun", function(opts)
-	local args = vim.split(opts.args, " ")
-	if vim.tbl_contains({ "upload", "build", "clean" }, args[1]) then -- check valid commands
-		require("platformio.piorun").piorun(args)
+	local args = opts.args
+	if args == "upload" then -- checking valid commands
+		require("platformio.piorun").pioupload()
+	elseif args == "build" then
+		require("platformio.piorun").piobuild()
+	elseif args == "clean" then
+		require("platformio.piorun").pioclean()
 	else
 		vim.api.nvim_err_writeln("Invalid argument. Use 'upload', 'build', or 'clean'.") -- error message if the cmd is invalid
 	end

--- a/plugin/platformio.lua
+++ b/plugin/platformio.lua
@@ -29,7 +29,7 @@ end, {
 
 -- Piomon
 vim.api.nvim_create_user_command("Piomon", function(opts)
-	local args = opts.args
+	local args = opts.args -- the piomon function will take care of argument error
 	if args == 0 then
 		require("platformio.piomon").piomon(0)
 	else
@@ -38,6 +38,14 @@ vim.api.nvim_create_user_command("Piomon", function(opts)
 end, {})
 
 -- Piolib
-vim.api.nvim_create_user_command("Piolib", function()
-	require("platformio.piolib").piolib()
-end, {})
+vim.api.nvim_create_user_command("Piolib", function(opts)
+	-- Split the args into a table
+	local args = vim.split(opts.args, " ")
+
+	-- Call the piolib function with the arguments
+	require("platformio.piolib").piolib(args)
+end, {
+	nargs = "+", -- means can take another argument
+})
+
+-- TODO:: implement Piodebug and Pioterm

--- a/plugin/platformio.lua
+++ b/plugin/platformio.lua
@@ -1,9 +1,22 @@
+-- Pioinit
+vim.api.nvim_create_user_command(
+  "Pioinit",
+  function()
+    require("platformio.pioinit").pioinit()
+  end,
+  {}
+)
+
+-- Piodb
+-- vim.api.nvim_create_user_command("Piodb", require("platformio.piodb").piodb(), {})
+
+-- Piorun
 vim.api.nvim_create_user_command("Piorun", function(opts)
 	local args = vim.split(opts.args, " ")
-	if vim.tbl_contains({ "upload", "build", "clean" }, args[1]) then
+	if vim.tbl_contains({ "upload", "build", "clean" }, args[1]) then -- check valid commands
 		require("platformio.piorun").piorun(args)
 	else
-		vim.api.nvim_err_writeln("Invalid argument. Use 'upload', 'build', or 'clean'.")
+		vim.api.nvim_err_writeln("Invalid argument. Use 'upload', 'build', or 'clean'.") -- error message if the cmd is invalid
 	end
 end, {
 	nargs = 1, -- Only one argument is expected
@@ -11,3 +24,5 @@ end, {
 		return { "upload", "build", "clean" } -- Autocompletion options
 	end,
 })
+
+-- vim.api.nvim_create_user_command("MyFirstFunction", require("plugin_name").hello, {})

--- a/plugin/platformio.vim.bak
+++ b/plugin/platformio.vim.bak
@@ -1,8 +1,6 @@
-lua require('platformio.cmd_cmp')
-
 command Pioinit lua require('platformio.pioinit').pioinit()
 command Piodb lua require('platformio.piodb').piodb()
-command -nargs=* -complete=custom,v:lua.require'platformio.cmd_cmp'.complete_piorun Piorun lua require('platformio.piorun').piorun(<f-args>)
+command -nargs=* Piorun lua require('platformio.piorun').piorun(<f-args>)
 command -nargs=* Piocmd lua require('platformio.pioterm').piocmd({<f-args>})
 command -nargs=+ Piolib lua require('platformio.piolib').piolib({<f-args>})
 command -nargs=* Piomon lua require('platformio.piomon').piomon({<f-args>})

--- a/plugin/platformio.vim.bak
+++ b/plugin/platformio.vim.bak
@@ -1,6 +1,8 @@
+lua require('platformio.cmd_cmp')
+
 command Pioinit lua require('platformio.pioinit').pioinit()
 command Piodb lua require('platformio.piodb').piodb()
-command -nargs=* Piorun lua require('platformio.piorun').piorun(<f-args>)
+command -nargs=* -complete=custom,v:lua.require'platformio.cmd_cmp'.complete_piorun Piorun lua require('platformio.piorun').piorun(<f-args>)
 command -nargs=* Piocmd lua require('platformio.pioterm').piocmd({<f-args>})
 command -nargs=+ Piolib lua require('platformio.piolib').piolib({<f-args>})
 command -nargs=* Piomon lua require('platformio.piomon').piomon({<f-args>})


### PR DESCRIPTION
As per my issue in #9 I implemented adding argument by reimplementing platformio.vim in Lua, though I didn't remove it, and instead rename in as .vim.bak just in case.

It doesn't need other plugins as dependencies as its just reimplement existing feature.

Need other's check to be merge in upstream

thx, dhupee