### PR TITLE
Pio menu

### DIFF
--- a/doc/platformio.txt
+++ b/doc/platformio.txt
@@ -59,6 +59,15 @@ USAGE                                                    *platformio-usage*
 
                                    *:Piodebug*
 :Pidebug		 Starts the default PlatformIO debugger with gdb
+
+
+                                   *:Piomenu*
+:Piomenu                 Open a floating window with two panes. The left pane
+                         displays an interactive PlatformIO menu. Click on any
+                         command to run it, and the output will appear live in
+                         the right pane. Sections can be expanded or collapsed
+                         by clicking on them. Use 'q' to close the floating
+                         window.
 ==============================================================================
 
 vim:tw=78:sw=4:ts=8:ft=help:norl:noet:

--- a/doc/tags
+++ b/doc/tags
@@ -3,6 +3,7 @@
 :Piolib 	platformio.txt	/*:Piolib*
 :Piocmd 	platformio.txt	/*:Piocmd*
 :Piomon 	platformio.txt	/*:Piomon*
+:Piomenu 	platformio.txt	/*:Piomenu*
 PlatfromIO	platformio.txt	/*PlatfromIO*
 platformio-usage	platformio.txt	/*platformio-usage*
 platformio.txt	platformio.txt	/*platformio.txt*

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -22,9 +22,28 @@ function render_menu_entries()
   return lines
 end
 
-        end
+local function find_clicked_entry(row)
+  local current_line = 0
+
+  for _, section in ipairs(entries) do
+    current_line = current_line + 1
+    if row == current_line then
+      -- Clicked on section title, not command
+      return { type = "section", section = section }
     end
-    return lines
+
+    if section.is_open then
+      for _, item in ipairs(section.entries) do
+        current_line = current_line + 1
+        if row == current_line then
+          -- Clicked on a command item
+          return { type = "entry", command = item.command }
+        end
+      end
+    end
+  end
+
+  return nil
 end
 
 

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -46,58 +46,80 @@ local function find_clicked_entry(row)
   return nil
 end
 
+local function run_command_in_right(command)
+  -- Clear right buffer first
+  vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, {})
 
-local function setup_mouse_click_handler(buf, win)
+  -- Start a job asynchronously
+  Job:new({
+    command = "sh",
+    args = { "-c", command },
+    on_stdout = function(_, line)
+      vim.schedule(function()
+        vim.api.nvim_buf_set_lines(right_buf, -1, -1, false, { line })
+      end)
+    end,
+    on_stderr = function(_, line)
+      vim.schedule(function()
+        vim.api.nvim_buf_set_lines(right_buf, -1, -1, false, { line })
+      end)
+    end,
+    on_exit = function()
+      vim.schedule(function()
+        vim.api.nvim_buf_set_lines(right_buf, -1, -1, false, { "-- DONE --" })
+      end)
+    end,
+  }):start()
+end
+
+local function setup_mouse_click_handler()
   vim.on_key(function(key)
     if key == vim.api.nvim_replace_termcodes('<LeftMouse>', true, true, true) then
-      -- Defer cursor read AFTER mouse click is processed
       vim.defer_fn(function()
-        local pos = vim.api.nvim_win_get_cursor(win)
-        local row = pos[1]
-        local col = pos[2]
-        local line = vim.api.nvim_buf_get_lines(buf, row - 1, row, false)[1] or ""
+        if vim.api.nvim_get_current_win() ~= left_win then
+          return
+        end
 
-        vim.api.nvim_buf_set_lines(buf, 0, -1, false, render_menu_entries())
-        print(string.format("Mouse click: row=%d col=%d char='%s'", row, col, line:sub(col + 1, col + 1)))
-      end, 0) -- 0ms delay is enough to yield to next event
+        -- Now safe to handle click inside left_win
+        local pos = vim.api.nvim_win_get_cursor(left_win)
+        local row = pos[1]
+        local entry = find_clicked_entry(row)
+
+        if entry then
+          if entry.type == "section" then
+            entry.section.is_open = not entry.section.is_open
+            vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, render_menu_entries())
+          elseif entry.type == "entry" then
+            run_command_in_right(entry.command)
+          end
+        end
+      end, 0)
     end
   end, vim.api.nvim_create_namespace('mouse_click_ns'))
 end
 
 function M.open_floating_window()
-  -- Calculate main window size (80% of screen)
+  -- Calculate sizes
   local main_width = math.floor(vim.o.columns * 0.8)
   local main_height = math.floor(vim.o.lines * 0.8)
   local main_row = math.floor((vim.o.lines - main_height) / 2)
   local main_col = math.floor((vim.o.columns - main_width) / 2)
 
-  -- Calculate content area size inside the border
   local content_width = main_width - 2
   local content_height = main_height - 2
   local left_width = math.floor(content_width * 0.2)
   local right_width = content_width - left_width
 
-  -- Create two buffers
-  local left_buf = vim.api.nvim_create_buf(false, true)
-  local right_buf = vim.api.nvim_create_buf(false, true)
+  left_buf = vim.api.nvim_create_buf(false, true)
+  right_buf = vim.api.nvim_create_buf(false, true)
 
-  -- Write some text inside each
-  vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, {
-    "LEFT COLUMN",
-    "20% WIDTH",
-  })
-  vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, {
-    "RIGHT COLUMN",
-    "80% WIDTH",
-    "This is a bigger pane.",
-  })
+  vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, render_menu_entries())
+  vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, { "Output will appear here..." })
 
-  -- Calculate absolute positions for content inside the main border
   local content_row = main_row + 1
   local content_col = main_col + 1
 
-  -- Open left window (20% pane)
-  local left_win = vim.api.nvim_open_win(left_buf, false, {
+  left_win = vim.api.nvim_open_win(left_buf, true, {
     relative = "editor",
     row = content_row,
     col = content_col,
@@ -108,24 +130,22 @@ function M.open_floating_window()
     border = "rounded",
   })
 
-  -- Open right window (80% pane)
-  local right_win = vim.api.nvim_open_win(right_buf, false, {
+  right_win = vim.api.nvim_open_win(right_buf, false, {
     relative = "editor",
     row = content_row,
-    col = content_col + left_width+2,
+    col = content_col + left_width + 2,
     width = right_width,
     height = content_height,
-    focusable = false,
+    focusable = true,
     style = "minimal",
     border = "rounded",
   })
 
+  setup_mouse_click_handler()
 
-setup_mouse_click_handler(left_buf, left_win)
-vim.api.nvim_set_current_win(left_win)
+  vim.api.nvim_set_current_win(left_win)
 
-
-  -- Handle 'q' key
+  -- Handle 'q'
   vim.api.nvim_buf_set_keymap(left_buf, 'n', 'q', '', {
     nowait = true,
     noremap = true,
@@ -135,7 +155,6 @@ vim.api.nvim_set_current_win(left_win)
       pcall(vim.api.nvim_win_close, left_win, true)
     end,
   })
-
 end
 
 return M

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -46,27 +46,29 @@ local function find_clicked_entry(row)
   return nil
 end
 
+
 local function run_command_in_right(command)
-  -- Clear right buffer first
   vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, {})
 
-  -- Start a job asynchronously
   Job:new({
     command = "sh",
     args = { "-c", command },
     on_stdout = function(_, line)
       vim.schedule(function()
         vim.api.nvim_buf_set_lines(right_buf, -1, -1, false, { line })
+        vim.api.nvim_win_set_cursor(right_win, { vim.api.nvim_buf_line_count(right_buf), 0 })
       end)
     end,
     on_stderr = function(_, line)
       vim.schedule(function()
         vim.api.nvim_buf_set_lines(right_buf, -1, -1, false, { line })
+        vim.api.nvim_win_set_cursor(right_win, { vim.api.nvim_buf_line_count(right_buf), 0 })
       end)
     end,
     on_exit = function()
       vim.schedule(function()
         vim.api.nvim_buf_set_lines(right_buf, -1, -1, false, { "-- DONE --" })
+        vim.api.nvim_win_set_cursor(right_win, { vim.api.nvim_buf_line_count(right_buf), 0 })
       end)
     end,
   }):start()
@@ -147,6 +149,15 @@ function M.open_floating_window()
 
   -- Handle 'q'
   vim.api.nvim_buf_set_keymap(left_buf, 'n', 'q', '', {
+    nowait = true,
+    noremap = true,
+    silent = true,
+    callback = function()
+      pcall(vim.api.nvim_win_close, right_win, true)
+      pcall(vim.api.nvim_win_close, left_win, true)
+    end,
+  })
+  vim.api.nvim_buf_set_keymap(right_buf, 'n', 'q', '', {
     nowait = true,
     noremap = true,
     silent = true,

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -2,6 +2,23 @@ local entries = require("platformio.piomenu_entries")
 
 local M = {}
 
+
+function render_menu_entries()
+    local lines = {}
+    for _, section in ipairs(entries) do
+        local line = (section.is_open and " " or " ") .. section.title
+        table.insert(lines, line)
+
+        if section.is_open then
+            for _, item in ipairs(section.entries) do
+                local subline = "\t" .. item.title
+                table.insert(lines, subline)
+            end
+        end
+    end
+    return lines
+end
+
 local function setup_mouse_click_handler(buf, win)
   vim.on_key(function(key)
     if key == vim.api.nvim_replace_termcodes('<LeftMouse>', true, true, true) then
@@ -11,11 +28,7 @@ local function setup_mouse_click_handler(buf, win)
       local col = pos[2]
       local line = vim.api.nvim_buf_get_lines(buf, row - 1, row, false)[1] or ""
 
-        vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
-          "Hello World",
-          "This is line 2",
-          "Another line"
-        })
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, render_menu_entries())
       print(string.format("Mouse click: row=%d col=%d char='%s'", row, col, line:sub(col + 1, col + 1)))
     end
   end, vim.api.nvim_create_namespace('mouse_click_ns'))

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -1,5 +1,5 @@
 local entries = require("platformio.piomenu_entries")
-local Job = require("plenary.job")  -- use plenary for async shell jobs easily
+local Job = require("plenary.job")
 
 local M = {}
 
@@ -14,7 +14,7 @@ function render_menu_entries()
 
     if section.is_open then
       for _, item in ipairs(section.entries) do
-        local subline = "\t" .. item.title
+        local subline = "      " .. item.title
         table.insert(lines, subline)
       end
     end
@@ -28,7 +28,6 @@ local function find_clicked_entry(row)
   for _, section in ipairs(entries) do
     current_line = current_line + 1
     if row == current_line then
-      -- Clicked on section title, not command
       return { type = "section", section = section }
     end
 
@@ -82,7 +81,6 @@ local function setup_mouse_click_handler()
           return
         end
 
-        -- Now safe to handle click inside left_win
         local pos = vim.api.nvim_win_get_cursor(left_win)
         local row = pos[1]
         local entry = find_clicked_entry(row)
@@ -100,10 +98,10 @@ local function setup_mouse_click_handler()
   end, vim.api.nvim_create_namespace('mouse_click_ns'))
 end
 
-function M.open_floating_window()
+function M.piomenu()
   -- Calculate sizes
-  local main_width = math.floor(vim.o.columns * 0.8)
-  local main_height = math.floor(vim.o.lines * 0.8)
+  local main_width = math.floor(vim.o.columns * 0.9)
+  local main_height = math.floor(vim.o.lines * 0.9)
   local main_row = math.floor((vim.o.lines - main_height) / 2)
   local main_col = math.floor((vim.o.columns - main_width) / 2)
 
@@ -118,7 +116,7 @@ function M.open_floating_window()
   vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, render_menu_entries())
   vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, { "Output will appear here..." })
 
-  local content_row = main_row + 1
+  local content_row = main_row - 1
   local content_col = main_col + 1
 
   left_win = vim.api.nvim_open_win(left_buf, true, {

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -1,3 +1,4 @@
+local entries = require("platformio.piomenu_entries")
 
 local M = {}
 

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -118,7 +118,7 @@ function M.piomenu()
     end
 
   }
-  menu_term:toggle()
+  menu_term:open()
 
 
   left_win = vim.api.nvim_open_win(left_buf, true, {

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -52,6 +52,12 @@ local function run_command_in_right(command)
   Job:new({
     command = "sh",
     args = { "-c", command },
+    on_start = function()
+      vim.schedule(function()
+        vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, { "Executing: " .. command, "" })
+        vim.api.nvim_win_set_cursor(right_win, { vim.api.nvim_buf_line_count(right_buf), 0 })
+      end)
+    end,
     on_stdout = function(_, line)
       vim.schedule(function()
         vim.api.nvim_buf_set_lines(right_buf, -1, -1, false, { line })

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -1,0 +1,97 @@
+
+local M = {}
+
+local function setup_mouse_click_handler(buf, win)
+  vim.on_key(function(key)
+    if key == vim.api.nvim_replace_termcodes('<LeftMouse>', true, true, true) then
+      -- Mouse clicked
+      local pos = vim.api.nvim_win_get_cursor(win)
+      local row = pos[1]
+      local col = pos[2]
+      local line = vim.api.nvim_buf_get_lines(buf, row - 1, row, false)[1] or ""
+
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+          "Hello World",
+          "This is line 2",
+          "Another line"
+        })
+      print(string.format("Mouse click: row=%d col=%d char='%s'", row, col, line:sub(col + 1, col + 1)))
+    end
+  end, vim.api.nvim_create_namespace('mouse_click_ns'))
+end
+
+function M.open_floating_window()
+  -- Calculate main window size (80% of screen)
+  local main_width = math.floor(vim.o.columns * 0.8)
+  local main_height = math.floor(vim.o.lines * 0.8)
+  local main_row = math.floor((vim.o.lines - main_height) / 2)
+  local main_col = math.floor((vim.o.columns - main_width) / 2)
+
+  -- Calculate content area size inside the border
+  local content_width = main_width - 2
+  local content_height = main_height - 2
+  local left_width = math.floor(content_width * 0.2)
+  local right_width = content_width - left_width
+
+  -- Create two buffers
+  local left_buf = vim.api.nvim_create_buf(false, true)
+  local right_buf = vim.api.nvim_create_buf(false, true)
+
+  -- Write some text inside each
+  vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, {
+    "LEFT COLUMN",
+    "20% WIDTH",
+  })
+  vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, {
+    "RIGHT COLUMN",
+    "80% WIDTH",
+    "This is a bigger pane.",
+  })
+
+  -- Calculate absolute positions for content inside the main border
+  local content_row = main_row + 1
+  local content_col = main_col + 1
+
+  -- Open left window (20% pane)
+  local left_win = vim.api.nvim_open_win(left_buf, false, {
+    relative = "editor",
+    row = content_row,
+    col = content_col,
+    width = left_width,
+    height = content_height,
+    focusable = true,
+    style = "minimal",
+    border = "rounded",
+  })
+
+  -- Open right window (80% pane)
+  local right_win = vim.api.nvim_open_win(right_buf, false, {
+    relative = "editor",
+    row = content_row,
+    col = content_col + left_width+2,
+    width = right_width,
+    height = content_height,
+    focusable = false,
+    style = "minimal",
+    border = "rounded",
+  })
+
+
+setup_mouse_click_handler(left_buf, left_win)
+vim.api.nvim_set_current_win(left_win)
+
+
+  -- Handle 'q' key
+  vim.api.nvim_buf_set_keymap(left_buf, 'n', 'q', '', {
+    nowait = true,
+    noremap = true,
+    silent = true,
+    callback = function()
+      pcall(vim.api.nvim_win_close, right_win, true)
+      pcall(vim.api.nvim_win_close, left_win, true)
+    end,
+  })
+
+end
+
+return M

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -8,18 +8,27 @@ local right_buf, right_win
 
 function render_menu_entries()
   local lines = {}
+  local highlights = {}
+
   for _, section in ipairs(entries) do
     local line = (section.is_open and " " or " ") .. section.title
     table.insert(lines, line)
+    table.insert(highlights, { hl_group = "Function", linenr = #lines - 1 })
 
     if section.is_open then
       for _, item in ipairs(section.entries) do
-        local subline = "      " .. item.title
+        local subline = "    " .. item.title
         table.insert(lines, subline)
+        table.insert(highlights, { hl_group = "String", linenr = #lines - 1 })
       end
     end
   end
-  return lines
+
+  vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, lines)
+
+  for _, hl in ipairs(highlights) do
+    vim.api.nvim_buf_add_highlight(left_buf, -1, hl.hl_group, hl.linenr, 0, -1)
+  end
 end
 
 local function find_clicked_entry(row)
@@ -94,7 +103,8 @@ local function setup_mouse_click_handler()
         if entry then
           if entry.type == "section" then
             entry.section.is_open = not entry.section.is_open
-            vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, render_menu_entries())
+            -- vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, ))
+            render_menu_entries()
           elseif entry.type == "entry" then
             run_command_in_right(entry.command)
           end
@@ -119,7 +129,8 @@ function M.piomenu()
   left_buf = vim.api.nvim_create_buf(false, true)
   right_buf = vim.api.nvim_create_buf(false, true)
 
-  vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, render_menu_entries())
+  -- vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, )
+  render_menu_entries()
   vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, { "Output will appear here..." })
 
   local content_row = main_row - 1

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -1,19 +1,27 @@
 local entries = require("platformio.piomenu_entries")
+local Job = require("plenary.job")  -- use plenary for async shell jobs easily
 
 local M = {}
 
+local left_buf, left_win
+local right_buf, right_win
 
 function render_menu_entries()
-    local lines = {}
-    for _, section in ipairs(entries) do
-        local line = (section.is_open and " " or " ") .. section.title
-        table.insert(lines, line)
+  local lines = {}
+  for _, section in ipairs(entries) do
+    local line = (section.is_open and " " or " ") .. section.title
+    table.insert(lines, line)
 
-        if section.is_open then
-            for _, item in ipairs(section.entries) do
-                local subline = "\t" .. item.title
-                table.insert(lines, subline)
-            end
+    if section.is_open then
+      for _, item in ipairs(section.entries) do
+        local subline = "\t" .. item.title
+        table.insert(lines, subline)
+      end
+    end
+  end
+  return lines
+end
+
         end
     end
     return lines

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -19,17 +19,20 @@ function render_menu_entries()
     return lines
 end
 
+
 local function setup_mouse_click_handler(buf, win)
   vim.on_key(function(key)
     if key == vim.api.nvim_replace_termcodes('<LeftMouse>', true, true, true) then
-      -- Mouse clicked
-      local pos = vim.api.nvim_win_get_cursor(win)
-      local row = pos[1]
-      local col = pos[2]
-      local line = vim.api.nvim_buf_get_lines(buf, row - 1, row, false)[1] or ""
+      -- Defer cursor read AFTER mouse click is processed
+      vim.defer_fn(function()
+        local pos = vim.api.nvim_win_get_cursor(win)
+        local row = pos[1]
+        local col = pos[2]
+        local line = vim.api.nvim_buf_get_lines(buf, row - 1, row, false)[1] or ""
 
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, render_menu_entries())
-      print(string.format("Mouse click: row=%d col=%d char='%s'", row, col, line:sub(col + 1, col + 1)))
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, render_menu_entries())
+        print(string.format("Mouse click: row=%d col=%d char='%s'", row, col, line:sub(col + 1, col + 1)))
+      end, 0) -- 0ms delay is enough to yield to next event
     end
   end, vim.api.nvim_create_namespace('mouse_click_ns'))
 end

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -143,7 +143,7 @@ function M.piomenu()
     noremap = true,
     silent = true,
     callback = function()
-      menu_term:send("exit", true)
+      menu_term:close()
       pcall(vim.api.nvim_win_close, left_win, true)
     end,
   })
@@ -153,7 +153,7 @@ function M.piomenu()
     noremap = true,
     silent = true,
     callback = function()
-      menu_term:send("exit", true)
+      menu_term:close()
       pcall(vim.api.nvim_win_close, left_win, true)
     end,
   })

--- a/lua/platformio/piomenu_entries.lua
+++ b/lua/platformio/piomenu_entries.lua
@@ -1,0 +1,56 @@
+local menu = {
+    ["General"] = {
+        ["is_open"] = false,
+        ['entries'] = {
+            ["Build"] = "pio run",
+            ["Upload"] = "pio run --verbose --target upload",
+            ["Monitor"] = "pio run --target monitor",
+            ["Upload and Monitor"] = "pio run --target upload --target monitor",
+            ["Clean"] = "pio run --target clean",
+            ["Full Clean"] = "platformio run --target fullclean",
+            ["Devices"] = "platformio device list",
+        }
+    },
+
+    ["Dependencies"] = {
+        ["is_open"] = false,
+        ['entries'] = {
+            ["List"] = "pio pkg list",
+            ["Outdated"] = "pio pkg outdated",
+            ["Update"] = "pio pkg update",
+        }
+    },
+
+    ["Advanced"] = {
+        ["is_open"] = false,
+        ['entries'] = {
+            ["Test"] = "pio test",
+            ["Check"] = "pio check",
+            ["Pre-Debug"] = "pio debug",
+            ["Verbose Build"] = "pio run --verbose",
+            ["Verbose Upload"] = "pio run --verbose --target upload",
+            ["Verbose Test"] = "pio test --verbose",
+            ["Verbose Check"] = "pio check --verbose",
+            ["Compilation Database"] = "pio run --target compiledb",
+        }
+    },
+
+    ["Remote"] = {
+        ["is_open"] = false,
+        ['entries'] = {
+            ["Remote Upload"] = "pio remote run --target upload",
+            ["Remote Test"] = "pio remote test",
+            ["Remote Monitor"] = "pio remote device monitor",
+            ["Remote Devices"] = "pio remote device list",
+        }
+    },
+
+    ["Miscellaneous"] = {
+        ["is_open"] = false,
+        ['entries'] = {
+            ["Upgrade PlatformIO Core"] = "pio upgrade",
+        }
+    },
+}
+
+return menu

--- a/lua/platformio/piomenu_entries.lua
+++ b/lua/platformio/piomenu_entries.lua
@@ -1,56 +1,58 @@
-local menu = {
-    ["General"] = {
-        ["is_open"] = false,
-        ['entries'] = {
-            ["Build"] = "pio run",
-            ["Upload"] = "pio run --verbose --target upload",
-            ["Monitor"] = "pio run --target monitor",
-            ["Upload and Monitor"] = "pio run --target upload --target monitor",
-            ["Clean"] = "pio run --target clean",
-            ["Full Clean"] = "platformio run --target fullclean",
-            ["Devices"] = "platformio device list",
-        }
+local entries = {
+    {
+        title = "General",
+        is_open = true,
+        entries = {
+            { title = "Build", command = "pio run" },
+            { title = "Upload", command = "pio run --verbose --target upload" },
+            { title = "Monitor", command = "pio run --target monitor" },
+            { title = "Upload and Monitor", command = "pio run --target upload --target monitor" },
+            { title = "Clean", command = "pio run --target clean" },
+            { title = "Full Clean", command = "platformio run --target fullclean" },
+            { title = "Devices", command = "platformio device list" },
+        },
     },
-
-    ["Dependencies"] = {
-        ["is_open"] = false,
-        ['entries'] = {
-            ["List"] = "pio pkg list",
-            ["Outdated"] = "pio pkg outdated",
-            ["Update"] = "pio pkg update",
-        }
+    {
+        title = "Dependencies",
+        is_open = false,
+        entries = {
+            { title = "List", command = "pio pkg list" },
+            { title = "Outdated", command = "pio pkg outdated" },
+            { title = "Update", command = "pio pkg update" },
+        },
     },
-
-    ["Advanced"] = {
-        ["is_open"] = false,
-        ['entries'] = {
-            ["Test"] = "pio test",
-            ["Check"] = "pio check",
-            ["Pre-Debug"] = "pio debug",
-            ["Verbose Build"] = "pio run --verbose",
-            ["Verbose Upload"] = "pio run --verbose --target upload",
-            ["Verbose Test"] = "pio test --verbose",
-            ["Verbose Check"] = "pio check --verbose",
-            ["Compilation Database"] = "pio run --target compiledb",
-        }
+    {
+        title = "Advanced",
+        is_open = false,
+        entries = {
+            { title = "Test", command = "pio test" },
+            { title = "Check", command = "pio check" },
+            { title = "Pre-Debug", command = "pio debug" },
+            { title = "Verbose Build", command = "pio run --verbose" },
+            { title = "Verbose Upload", command = "pio run --verbose --target upload" },
+            { title = "Verbose Test", command = "pio test --verbose" },
+            { title = "Verbose Check", command = "pio check --verbose" },
+            { title = "Compilation Database", command = "pio run --target compiledb" },
+        },
     },
-
-    ["Remote"] = {
-        ["is_open"] = false,
-        ['entries'] = {
-            ["Remote Upload"] = "pio remote run --target upload",
-            ["Remote Test"] = "pio remote test",
-            ["Remote Monitor"] = "pio remote device monitor",
-            ["Remote Devices"] = "pio remote device list",
-        }
+    {
+        title = "Remote",
+        is_open = false,
+        entries = {
+            { title = "Remote Upload", command = "pio remote run --target upload" },
+            { title = "Remote Test", command = "pio remote test" },
+            { title = "Remote Monitor", command = "pio remote device monitor" },
+            { title = "Remote Devices", command = "pio remote device list" },
+        },
     },
-
-    ["Miscellaneous"] = {
-        ["is_open"] = false,
-        ['entries'] = {
-            ["Upgrade PlatformIO Core"] = "pio upgrade",
-        }
+    {
+        title = "Miscellaneous",
+        is_open = false,
+        entries = {
+            { title = "Upgrade PlatformIO Core", command = "pio upgrade" },
+        },
     },
 }
 
-return menu
+
+return entries

--- a/lua/platformio/utils.lua
+++ b/lua/platformio/utils.lua
@@ -131,13 +131,16 @@ function M.file_exists(name)
   end
 end
 
-function M.cd_pioini()
+function M.get_pioini_path()
   for _, path in pairs(paths) do
     if M.file_exists(path .. '/platformio.ini') then
-      vim.cmd('cd ' .. path)
-      break
+      return path
     end
   end
+end
+
+function M.cd_pioini()
+  vim.cmd('cd ' .. M.get_pioini_path())
 end
 
 function M.pio_install_check()

--- a/plugin/platformio.lua
+++ b/plugin/platformio.lua
@@ -59,3 +59,8 @@ end, {
 vim.api.nvim_create_user_command('Piodebug', function()
   require('platformio.piodebug').piodebug()
 end, {})
+
+-- Piomenu
+vim.api.nvim_create_user_command('Piomenu', function()
+  require('platformio.piomenu').piomenu()
+end, {})


### PR DESCRIPTION
This menu subsystem is replica of PlatformIO IDE's tasks which looks like this
![image](https://github.com/user-attachments/assets/e211512d-643d-42ed-8ffd-713972a74d05)

I added a new command `:Piomenu` which gives you same UI where you have Categories and Commands. You can operate it using mouse or Enter key and press `q` to exit. Here is a demo of that.

https://github.com/user-attachments/assets/0ee42787-94b3-465d-bb43-38adde8756b5

I am open to add new commands and categories, currently I just added whatever you had in PlatfomIO IDE. This is the file needed to be changed
https://github.com/anurag3301/nvim-platformio.lua/blob/0b8bfa55bbd6814bcb5ef2c4d4e5189b6ed703a2/lua/platformio/piomenu_entries.lua#L1-L13

I'll prob not merge it now, currently I am using `plenary`'s job api to run shell command and show in a buffer, but it looses colour text which I kinda want, I have had lot of unsuccessful attems using `vim.fn.termopen`. 