### PR TITLE
use which-key.nvim plugin as a commands menu.

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -3,4 +3,4 @@ line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 2
 quote_style = "AutoPreferSingle"
-call_parentheses = "None"
+call_parentheses = "Always"

--- a/README.md
+++ b/README.md
@@ -28,53 +28,100 @@ Check the install instructions on the [PlatformIO docs](https://docs.platformio.
 
 
 #### Plugin
-Install the plugin using packer
-```lua
-use {
-    'anurag3301/nvim-platformio.lua',
-    requires = {
-        {'akinsho/nvim-toggleterm.lua'},
-        {'nvim-telescope/telescope.nvim'},
-        {'nvim-lua/plenary.nvim'},
-    }
-}
-```
-Or Install the plugin using lazy
+Install the plugin using lazy
 ```lua
 return {
-    "anurag3301/nvim-platformio.lua",
-    dependencies = {
-        { "akinsho/nvim-toggleterm.lua" },
-        { "nvim-telescope/telescope.nvim" },
-        { "nvim-lua/plenary.nvim" },
+  'anurag3301/nvim-platformio.lua',
+  -- cmd = { 'Pioinit', 'Piorun', 'Piocmdh', 'Piocmdf', 'Piolib', 'Piomon', 'Piodebug', 'Piodb' },
+
+  -- dependencies are always lazy-loaded unless specified otherwise
+  dependencies = {
+    { 'akinsho/toggleterm.nvim' },
+    { 'nvim-telescope/telescope.nvim' },
+    { 'nvim-lua/plenary.nvim' },
+    {
+      -- WhichKey helps you remember your Neovim keymaps,
+      -- by showing available keybindings in a popup as you type.
+      'folke/which-key.nvim',
+      opts = {
+        preset = 'helix', --'modern', --"classic", --
+        sort = { 'order', 'group', 'manual', 'mod' },
+      },
     },
+  },
+
+  config = function()
+    require('platformio').setup({
+      lsp = 'clangd', --default: ccls, other option: clangd
+      -- If you pick clangd, it also creates compile_commands.json
+    })
+
+    local ok, wk = pcall(require, 'which-key') --will also load the package if it isn't loaded already
+    if not ok then
+      vim.api.nvim_echo({
+        { 'which-key plugin not found!', 'ErrorMsg' },
+      }, true, {})
+    else
+      local prefix = '<leader>p' -- or use 'gp'
+      local Piocmd = 'Piocmdf'   -- 'Piocmdh' (horizontal terminal)  'Piocmdf' (float terminal)
+      wk.add({
+        { prefix .. '', group = ' PlatformIO:' },
+        { prefix .. 'g', group = '  [g]eneral' },
+        { prefix .. 'd', group = '  [d]ependencies' },
+        { prefix .. 'a', group = '  [a]dvance' },
+        { prefix .. 'av', group = '  [v]erbose' },
+        { prefix .. 'r', group = '  [r]emote' },
+        { prefix .. 'm', group = '  [m]iscellaneous' },
+        {
+          mode = { 'n', 'v' }, -- NORMAL and VISUAL mode
+          { prefix .. 'gb', '<cmd>' .. Piocmd .. ' run<CR>', desc = ' [b]uild' },
+          { prefix .. 'gc', '<cmd>' .. Piocmd .. ' run -t clean<CR>', desc = ' [c]lean' },
+          { prefix .. 'gf', '<cmd>' .. Piocmd .. ' run -t fullclean<CR>', desc = ' [f]ull clean' },
+          { prefix .. 'gd', '<cmd>' .. Piocmd .. ' device list<CR>', desc = ' [d]evice list' },
+          { prefix .. 'gm', '<cmd>' .. 'Piocmdh' .. ' run -t monitor<CR>', desc = ' [m]onitor' },
+          { prefix .. 'gu', '<cmd>' .. Piocmd .. ' run -t upload<CR>', desc = ' [u]pload' },
+          { prefix .. 'gs', '<cmd>' .. Piocmd .. ' run -t uploadfs<CR>', desc = ' upload file [s]ystem' },
+          { prefix .. 'gt', '<cmd>' .. Piocmd .. '<CR>', desc = ' Core CLI [T]erminal' },
+
+          { prefix .. 'dl', '<cmd>' .. Piocmd .. ' pkg list<CR>', desc = ' [l]ist packages' },
+          { prefix .. 'do', '<cmd>' .. Piocmd .. ' pkg outdated<CR>', desc = ' List [o]utdated packages' },
+          { prefix .. 'du', '<cmd>' .. Piocmd .. ' pkg update<CR>', desc = ' [u]pdate packages' },
+
+          { prefix .. 'at', '<cmd>' .. Piocmd .. ' test<CR>', desc = ' [t]est' },
+          { prefix .. 'ac', '<cmd>' .. Piocmd .. ' check<CR>', desc = ' [c]heck' },
+          { prefix .. 'ad', '<cmd>' .. Piocmd .. ' debug<CR>', desc = ' [d]ebug' },
+          { prefix .. 'ab', '<cmd>' .. Piocmd .. ' run -t compiledb<CR>', desc = ' compilation data[b]ase' },
+
+          { prefix .. 'av', '<cmd>' .. Piocmd .. ' debug<CR>', desc = ' [v]erbose' },
+          { prefix .. 'avb', '<cmd>' .. Piocmd .. ' run -v<CR>', desc = ' [b]uild' },
+          { prefix .. 'avd', '<cmd>' .. Piocmd .. ' debug -v<CR>', desc = ' [d]ebug' },
+          { prefix .. 'avu', '<cmd>' .. Piocmd .. ' run -v -t upload<CR>', desc = ' [u]pload' },
+          { prefix .. 'avs', '<cmd>' .. Piocmd .. ' run -v -t uploadfs<CR>', desc = ' upload file [s]ystem' },
+          { prefix .. 'avt', '<cmd>' .. Piocmd .. ' test -v<CR>', desc = ' [t]est' },
+          { prefix .. 'avc', '<cmd>' .. Piocmd .. ' check -v<CR>', desc = ' [c]heck' },
+          { prefix .. 'ava', '<cmd>' .. Piocmd .. ' run -v -t compiledb<CR>', desc = ' compilation databa[a]e' },
+
+          { prefix .. 'ru', '<cmd>' .. Piocmd .. ' remote run -t upload<CR>', desc = ' [u]pload' },
+          { prefix .. 'rt', '<cmd>' .. Piocmd .. ' remote test<CR>', desc = ' [t]est' },
+          { prefix .. 'rm', '<cmd>' .. 'Piocmdh' .. ' remote run -t monitor<CR>', desc = ' [m]onitor' },
+          { prefix .. 'rd', '<cmd>' .. Piocmd .. ' remote device list<CR>', desc = ' [d]evice list' },
+
+          { prefix .. 'mu', '<cmd>' .. Piocmd .. ' upgrade<CR>', desc = ' [u]pgrade' },
+        },
+      })
+    end
+  end,
 }
 ```
 
 #### Usage `:h PlatformIO`
-
-### Configuration
-```lua
-require('platformio').setup({
-    lsp = "ccls" --default: ccls, other option: clangd
-                 -- If you pick clangd, it also creates compile_commands.json
-})
-```
 
 ### Lazy loading
 
 It's possible to lazy load the plugin using Lazy.nvim, this will load the plugins only when it is needed, to enable lazy loading, add this plugin spec to your config.
 
 ```lua
-cmd = {
-    "Pioinit",
-    "Piorun",
-    "Piocmd",
-    "Piolib",
-    "Piomon",
-    "Piodebug",
-    "Piodb",
-},
+cmd = { 'Pioinit', 'Piorun', 'Piocmdh', 'Piocmdf', 'Piolib', 'Piomon', 'Piodebug', 'Piodb' },
 ```
 
 

--- a/doc/platformio.txt
+++ b/doc/platformio.txt
@@ -30,16 +30,17 @@ USAGE                                                    *platformio-usage*
                             `:Piorun clean`
 
                                    *:Piocmd*
-:Piocmd [cmd]           Run PlatformIO commands. Example: `:Piocmd device list`.
+:Piocmd[f|h] [cmd]       Run PlatformIO commands either in float or horizontal direction.
+                         Example: `:Piocmdf device list`.
                          The command argument is optional. If not provided, it
                          opens a floating toggleterm in the project root where
                          you can execute commands. Note: `pio` keyword is not
                          required in the command.
                          Examples:
-                            `:Piocmd`
-                            `:Piocmd run -e uno -t upload`
-                            `:Piocmd device list`
-                            `:Piocmd boards arduinouno --json-output`
+                            `:Piocmdh`
+                            `:Piocmdh run -e uno -t upload`
+                            `:Piocmdf device list`
+                            `:Piocmdf boards arduinouno --json-output`
 
                                    *:Piolib*
 :Piolib [libname]       Install a library by providing a keyword for search. A

--- a/doc/tags
+++ b/doc/tags
@@ -1,7 +1,8 @@
 :Pioinit	platformio.txt	/*:Pioinit*
 :Piorun	    platformio.txt	/*:Piorun*
 :Piolib 	platformio.txt	/*:Piolib*
-:Piocmd 	platformio.txt	/*:Piocmd*
+:Piocmdf 	platformio.txt	/*:Piocmdf*
+:Piocmdh 	platformio.txt	/*:Piocmdh*
 :Piomon 	platformio.txt	/*:Piomon*
 :Piomenu 	platformio.txt	/*:Piomenu*
 PlatfromIO	platformio.txt	/*PlatfromIO*

--- a/lua/platformio/init.lua
+++ b/lua/platformio/init.lua
@@ -1,27 +1,24 @@
 local M = {}
 
 local default_config = {
-    lsp = 'ccls',
+  lsp = 'ccls',
 }
 
 M.config = vim.deepcopy(default_config)
 
 function M.setup(user_config)
-    local valid_keys = {
-        lsp = true,
-    }
-    for key, _ in pairs(user_config or {}) do
-        if not valid_keys[key] then
-            local error_message = string.format(
-                "Invalid configuration key: '%s'\n%s",
-                key,
-                debug.traceback("Stack trace:")
-            )
-            vim.api.nvim_err_writeln(error_message)
-            return
-        end
+  local valid_keys = {
+    lsp = true,
+  }
+  for key, _ in pairs(user_config or {}) do
+    if not valid_keys[key] then
+      local error_message = string.format("Invalid configuration key: '%s'\n%s", key, debug.traceback 'Stack trace:')
+      -- vim.api.nvim_err_writeln(error_message) -- deprecated
+      vim.api.nvim_echo({ { error_message, 'ErrorMsg' } }, true, {}) -- replaced deprecated function
+      return
     end
-    M.config = vim.tbl_deep_extend('force', default_config, user_config or {})
+  end
+  M.config = vim.tbl_deep_extend('force', default_config, user_config or {})
 end
 
 return M

--- a/lua/platformio/piocmd.lua
+++ b/lua/platformio/piocmd.lua
@@ -1,22 +1,21 @@
 local utils = require("platformio.utils")
 local M = {}
 
-function M.piocmd(cmd_table)
+function M.piocmd(cmd_table, direction)
   if not utils.pio_install_check() then
     return
   end
 
   utils.cd_pioini()
 
-  if cmd_table[1] == '' then
-    vim.cmd("2ToggleTerm direction=float")
+  if cmd_table[1] == "" then
+    utils.ToggleTerminal("", direction)
   else
     local cmd = "pio "
     for _, v in pairs(cmd_table) do
       cmd = cmd .. " " .. v
     end
-    local command = cmd .. utils.extra
-    utils.ToggleTerminal(command, "float")
+    utils.ToggleTerminal(cmd, direction)
   end
 end
 

--- a/lua/platformio/piomon.lua
+++ b/lua/platformio/piomon.lua
@@ -1,4 +1,4 @@
-local utils = require("platformio.utils")
+local utils = require 'platformio.utils'
 local M = {}
 
 function M.piomon(args_table)
@@ -10,12 +10,12 @@ function M.piomon(args_table)
 
   local command
   if args_table[1] == '' then
-    command = "pio device monitor"
+    command = 'pio device monitor'
   else
     local baud_rate = args_table[1]
-    command = string.format("pio device monitor -b %s", baud_rate)
+    command = string.format('pio device monitor -b %s', baud_rate)
   end
-  utils.ToggleTerminal(command, "horizontal", "Press [Ctrl+C] then press ENTER to exit")
+  utils.ToggleTerminal(command, 'horizontal')
 end
 
 return M

--- a/lua/platformio/utils.lua
+++ b/lua/platformio/utils.lua
@@ -1,128 +1,231 @@
 local M = {}
 
 -- M.extra = 'printf \"\\\\n\\\\033[0;33mPlease Press ENTER to continue \\\\033[0m\"; read'
-M.extra = ' && echo . && echo . && echo Please Press ENTER to continue'
+M.extra = " && echo . && echo . && echo Please Press ENTER to continue"
 
 function M.strsplit(inputstr, del)
   local t = {}
-  for str in string.gmatch(inputstr, '([^' .. del .. ']+)') do
+  for str in string.gmatch(inputstr, "([^" .. del .. "]+)") do
     table.insert(t, str)
   end
   return t
 end
 
 local function pathmul(n)
-  return '..' .. string.rep('/..', n)
+  return ".." .. string.rep("/..", n)
 end
 
-----------------------------------------------------------------------------------------
-local platformio = vim.api.nvim_create_augroup('platformio', { clear = true })
-function M.ToggleTerminal(command, direction, title)
-  --
-  local Terminal = require('toggleterm.terminal').Terminal
-  local terminal = Terminal:new {
-    cmd = command,
+-------------------------------------------------
+local function setMode(target_mode)
+  if target_mode == "n" or target_mode == "nt" or target_mode == "normal" or target_mode == "normal_terminal" then
+    local esc_key = vim.api.nvim_replace_termcodes("<Esc>", true, false, true)
+    vim.api.nvim_feedkeys(esc_key, "n", false)
+    vim.api.nvim_feedkeys(esc_key, "n", false) -- Sending Esc twice is a common robust way
+  elseif target_mode == "i" or target_mode == "t" or target_mode == "insert" or target_mode == "terminal" then
+    vim.api.nvim_feedkeys("i", "n", false)
+  elseif target_mode == "v" or target_mode == "visual" then
+    vim.api.nvim_feedkeys("v", "n", false)
+  elseif target_mode == "V" or target_mode == "visual_line" then
+    vim.api.nvim_feedkeys("V", "n", false)
+  else
+    vim.api.nvim_echo({ { "Error: Unknown target mode '" .. target_mode .. "'", "ErrorMsg" } }, true, {})
+    return
+  end
+  -- Short delay to allow mode change to process, then get new mode
+  vim.defer_fn(function() end, 100) -- 100ms delay
+end
+---------------------------------------------
+---------------------------------------------
+function M.ToggleTerminal(command, direction)
+  local status_ok, _ = pcall(require, "toggleterm")
+  if not status_ok then
+    vim.api.nvim_echo({ { "toggleterm not found!", "ErrorMsg" } }, true, {})
+    return
+  end
+
+  local platformio = vim.api.nvim_create_augroup("platformio", { clear = true })
+  local origin_window = nil -- used to keep previous window id; to go back to after closing terminal
+
+  local title = "Pio CLI> " .. command
+  local id = 1 -- 2 for monitor terminal, 1 for other
+  if string.find(command, " monitor") then
+    title = "Pio CLI Monitor: Press [Ctrl+C] then press ENTER to exit"
+    id = 2
+  end
+  ------------------------------------------------------
+  ------termConfig: terminal configuration table--------
+  local termConfig = {
+    id = id,
     direction = direction,
+    float_opts = {
+      winblend = 0,
+      width = function()
+        return math.ceil(vim.o.columns * 0.85)
+      end,
+      height = function()
+        return math.ceil(vim.o.lines * 0.85)
+      end,
+      highlights = {
+        border = "FloatBorder",
+        background = "NormalFloat",
+      },
+    },
     close_on_exit = false,
-
     on_open = function(t)
-      --Only to set Piomon toggleterm winbar title/message
-      if title then
-        -- local hl = vim.api.nvim_get_hl(0, { name = "CurSearch" })
-        local hl = { bg = '#e4cf0e', fg = '#0012d9' }
-        vim.api.nvim_set_hl(0, 'MyWinBar', { bg = hl.bg, fg = hl.fg })
+      local hl = { bg = "#e4cf0e", fg = "#0012d9" }
+      vim.api.nvim_set_hl(0, "MyWinBar", { bg = hl.bg, fg = hl.fg })
 
-        local winBarTitle = '%#MyWinBar#' .. title .. '%*'
-        vim.api.nvim_set_option_value('winbar', winBarTitle, { scope = 'local', win = t.window })
+      local winBarTitle = "%#MyWinBar#" .. title .. "%*"
+      vim.api.nvim_set_option_value("winbar", winBarTitle, { scope = "local", win = t.window })
 
-        -- Following necessary to solve that some time winbar not showing
-        vim.schedule(function()
-          vim.api.nvim_set_option_value('winbar', winBarTitle, { scope = 'local', win = t.window })
-        end)
-      end
+      -- Following necessary to solve that some time winbar not showing
+      vim.schedule(function()
+        vim.api.nvim_set_option_value("winbar", winBarTitle, { scope = "local", win = t.window })
+      end)
+      vim.api.nvim_echo({
+        { "ToggleTerm ",                                   "MoreMsg" },
+        { "(Previous window ID: " .. origin_window .. ")", "MoreMsg" },
+        { "(Window ID: " .. t.window .. ")",               "MoreMsg" },
+        { "(terminal id: " .. t.id .. ")",                 "MoreMsg" },
+        { "(Job ID: " .. t.job_id .. ")",                  "MoreMsg" },
+      }, true, {})
     end,
-
     on_create = function(t)
-      t.set_mode(t, 'i')
-      --Only to set Piomon toggleterm winbar title/message
-      if title then
-        --set toggleterm to be in insert mode
+      --set toggleterm to be in terminal mode
+      setMode("terminal")
 
-        -- keymap toggleterm "Esc" and ":" keys to go command line
-        vim.keymap.set('t', '<Esc>', [[<C-\><C-n>k]], { noremap = true, buffer = t.bufnr })
-        vim.keymap.set('n', '<Esc>', [[<C-\><C-n>a]], { noremap = true, buffer = t.bufnr })
-        vim.keymap.set('n', '<C-c>', [[<C-\><C-n>a<C-c>]], { noremap = true, buffer = t.bufnr })
-        vim.keymap.set('t', ':', [[<C-\><C-n>:]], { noremap = true, buffer = t.bufnr })
-        vim.keymap.set('n', ':', [[<C-\><C-n>:]], { noremap = true, buffer = t.bufnr })
+      -- keymap toggleterm "Esc" and ":" keys to go command line
+      vim.keymap.set("t", "<Esc>", [[<C-\><C-n>k]], { noremap = true, buffer = t.bufnr })
+      vim.keymap.set("n", "<Esc>", [[<C-\><C-n>a]], { noremap = true, buffer = t.bufnr })
+      vim.keymap.set("n", "<C-c>", [[<C-\><C-n>a<C-c>]], { noremap = true, buffer = t.bufnr })
+      vim.keymap.set("t", ":", [[<C-\><C-n>:]], { noremap = true, buffer = t.bufnr })
+      vim.keymap.set("n", ":", [[<C-\><C-n>:]], { noremap = true, buffer = t.bufnr })
 
-        vim.api.nvim_create_autocmd('BufEnter', {
-          group = platformio,
-          desc = 'toggleterm buffer entered',
-          buffer = t.bufnr,
-          callback = function(args)
-            t.set_mode(t, 'i')
-          end,
-        })
+      vim.api.nvim_create_autocmd("BufEnter", {
+        group = platformio,
+        desc = "toggleterm buffer entered",
+        buffer = t.bufnr,
+        callback = function()
+          setMode("terminal")
+        end,
+      })
 
-        vim.api.nvim_create_autocmd('BufUnload', {
-          group = platformio,
-          desc = 'toggleterm buffer unloaded',
-          buffer = t.bufnr,
-          callback = function(args)
-            vim.keymap.del({ 'n', 't' }, ':', { buffer = args.buf })
-            vim.keymap.del({ 'n', 't' }, '<Esc>', { buffer = args.buf })
+      vim.api.nvim_create_autocmd("BufUnload", {
+        group = platformio,
+        desc = "toggleterm buffer unloaded",
+        buffer = t.bufnr,
+        callback = function(args)
+          vim.keymap.del({ "n", "t" }, ":", { buffer = args.buf })
+          vim.keymap.del({ "n", "t" }, "<Esc>", { buffer = args.buf })
 
-            vim.keymap.del('n', '<C-c>', { buffer = args.buf })
-            vim.keymap.set('t', '<Esc>', [[<C-\><C-n>]], { noremap = true, buffer = 0 })
+          vim.keymap.del("n", "<C-c>", { buffer = args.buf })
+          vim.keymap.set("t", "<Esc>", [[<C-\><C-n>]], { noremap = true, buffer = 0 })
 
-            -- clear autommmand when quit
-            vim.api.nvim_clear_autocmds { group = 'platformio' }
-          end,
-        })
+          -- clear autommmand when quit
+          vim.api.nvim_clear_autocmds({ group = "platformio" })
+        end,
+      })
 
-        vim.api.nvim_create_autocmd('QuitPre', {
-          group = platformio,
-          desc = 'shutdown terminl',
-          buffer = t.bufnr,
-          callback = function()
-            vim.api.nvim_exec_autocmds('BufUnload', { group = platformio, buffer = t.bufnr, data = t.bufnr })
-            -- do clean and proper toggleterm shutdown
-            t.set_mode(t, 'n')
-            t.shutdown(t)
-          end,
-        })
+      vim.api.nvim_create_autocmd("WinClosed", {
+        group = platformio,
+        desc = "shutdown terminl",
+        buffer = t.bufnr,
+        callback = function()
+          if vim.api.nvim_get_mode().mode == "nt" then
+            setMode("terminal")
+          end
+          if t.id == 1 then -- non monitor terminal
+            local enter = vim.api.nvim_replace_termcodes("<Enter>", true, false, true)
+            vim.api.nvim_feedkeys("exit" .. enter, "x", false)
+            -- vim.api.nvim_echo({ { 'WExit Pio_CLI!', 'MoreMsg' } }, true, {})
+          elseif t.id == 2 then -- monitor terminal
+            local ctrl_c = vim.api.nvim_replace_termcodes("<C-C>", true, true, true)
+            vim.api.nvim_feedkeys(ctrl_c, "x", false)
+            -- vim.api.nvim_echo({ { 'WExit Pio_Monitor!', 'MoreMsg' } }, true, {})
+          end
 
-        vim.api.nvim_create_autocmd('ModeChanged', {
-          -- Autocommand for modechanges of toggleterm buffer
-          group = platformio,
-          buffer = t.bufnr,
-          callback = function()
-            local old_mode = vim.v.event.old_mode
-            local new_mode = vim.v.event.new_mode
-            if new_mode == 'nt' and old_mode == 'c' then
-              -- after entering normal terminal mode comming back from command line mode,
-              -- below force terminal buffer to enter insert mode
-              t.set_mode(t, 'i')
-            end
-          end,
-        })
-      end
+          -- close terminal window
+          vim.api.nvim_win_close(t.window, true)
+
+          -- go back to previous window
+          if origin_window and vim.api.nvim_win_is_valid(origin_window) then
+            vim.api.nvim_set_current_win(origin_window)
+          end
+          setMode("normal")
+
+          -- delete terminal buffer
+          vim.api.nvim_buf_delete(t.bufnr, { force = true })
+        end,
+      })
+
+      vim.api.nvim_create_autocmd("QuitPre", {
+        group = platformio,
+        desc = "shutdown terminl",
+        buffer = t.bufnr,
+        callback = function()
+          if vim.api.nvim_get_mode().mode == "nt" then
+            setMode("terminal")
+          end
+          if t.id == 1 then -- non monitor terminal
+            local enter = vim.api.nvim_replace_termcodes("<Enter>", true, false, true)
+            vim.api.nvim_feedkeys("exit" .. enter, "x", false)
+            -- vim.api.nvim_echo({ { 'QExit Pio_CLI!', 'MoreMsg' } }, true, {})
+          elseif t.id == 2 then -- monitor terminal
+            local ctrl_c = vim.api.nvim_replace_termcodes("<C-C>", true, true, true)
+            vim.api.nvim_feedkeys(ctrl_c, "x", false)
+            -- vim.api.nvim_echo({ { 'QExit Pio_Monitor!', 'MoreMsg' } }, true, {})
+          end
+
+          -- close terminal window
+          vim.api.nvim_win_close(t.window, true)
+
+          -- go back to previous window
+          if origin_window and vim.api.nvim_win_is_valid(origin_window) then
+            vim.api.nvim_set_current_win(origin_window)
+          end
+          setMode("normal")
+
+          -- delete terminal buffer
+          vim.api.nvim_buf_delete(t.bufnr, { force = true })
+        end,
+      })
+
+      vim.api.nvim_create_autocmd("ModeChanged", {
+        desc = 'force terminal buffer to enter "t" mode; after entering "nt" mode comming back from command line mode',
+        group = platformio,
+        -- `:h mode()`
+        -- `c` means `command-line editing`
+        -- `nt` means `normal terminal mode`
+        pattern = { "c*:nt*" },
+        callback = function()
+          setMode("terminal")
+        end,
+      })
     end,
   }
+  -----termConfig: end terminal configuration table-----
+  ------------------------------------------------------
+
+  origin_window = vim.api.nvim_get_current_win()
+
+  -- to have PIO Cli terminal without running any command, omit the 'cmd' option in termConfig table
+  if command and command ~= "" then -- check if command string is not empty,
+    termConfig.cmd = command        -- add cmd to the setup table of toggleterm
+  end
+  local terminal = require("toggleterm.terminal").Terminal:new(termConfig)
   terminal:toggle()
 end
 
--- remove un-needed function
-
-local is_windows = jit.os == 'Windows'
+local is_windows = jit.os == "Windows"
 --
-M.devNul = is_windows and ' 2>./nul' or ' 2>/dev/null'
+M.devNul = is_windows and " 2>./nul" or " 2>/dev/null"
+M.enter = is_windows and "\r" or "\n"
 ----------------------------------------------------------------------------------------
 
-local paths = { '.', '..', pathmul(1), pathmul(2), pathmul(3), pathmul(4), pathmul(5) }
+local paths = { ".", "..", pathmul(1), pathmul(2), pathmul(3), pathmul(4), pathmul(5) }
 
 function M.file_exists(name)
-  local f = io.open(name, 'r')
+  local f = io.open(name, "r")
   if f ~= nil then
     io.close(f)
     return true
@@ -133,23 +236,24 @@ end
 
 function M.get_pioini_path()
   for _, path in pairs(paths) do
-    if M.file_exists(path .. '/platformio.ini') then
+    if M.file_exists(path .. "/platformio.ini") then
       return path
     end
   end
 end
 
 function M.cd_pioini()
-  vim.cmd('cd ' .. M.get_pioini_path())
+  vim.cmd("cd " .. M.get_pioini_path())
 end
 
 function M.pio_install_check()
-  local handel = (jit.os == 'Windows') and assert(io.popen 'where.exe pio 2>./nul') or assert(io.popen 'which pio 2>/dev/null')
-  local pio_path = assert(handel:read '*a')
+  local handel = (jit.os == "Windows") and assert(io.popen("where.exe pio 2>./nul")) or
+  assert(io.popen("which pio 2>/dev/null"))
+  local pio_path = assert(handel:read("*a"))
   handel:close()
 
   if #pio_path == 0 then
-    vim.notify('Platformio not found in the path', vim.log.levels.ERROR)
+    vim.notify("Platformio not found in the path", vim.log.levels.ERROR)
     return false
   end
   return true

--- a/plugin/platformio.lua
+++ b/plugin/platformio.lua
@@ -47,10 +47,18 @@ end, {
   nargs = '+',
 })
 
--- Piocmd
-vim.api.nvim_create_user_command('Piocmd', function(opts)
+-- Piocmdh    Piocmd horizontal terminal
+vim.api.nvim_create_user_command('Piocmdh', function(opts)
   local cmd_table = vim.split(opts.args, ' ')
-  require('platformio.piocmd').piocmd(cmd_table)
+  require('platformio.piocmd').piocmd(cmd_table, 'horizontal')
+end, {
+  nargs = '*',
+})
+
+-- Piocmdf    Piocmd float terminal
+vim.api.nvim_create_user_command('Piocmdf', function(opts)
+  local cmd_table = vim.split(opts.args, ' ')
+  require('platformio.piocmd').piocmd(cmd_table, 'float')
 end, {
   nargs = '*',
 })


### PR DESCRIPTION
Use which-key.nvim plugin as a commands menu using for example: <leader>p
This way; it is easy to memorize and execute the commands using keyboard only with no need for mouse.

Also, this way gives the user the flexibility to run the command in horizontal/vertical terminal. 

Nvim power is to do editing quickly without leaving the keyboard.
 