### PR TITLE
Added configurability to piomenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,56 @@ return {
 
 ```
 
+### Following are the default keybindings, you can overwrite them in the config
+```lua
+require('platformio').setup({
+
+  menu_bindings = {
+    { group = '  [g]eneral', key = 'g', elements = {
+      { key = 'b', cmd = 'run', desc = ' [b]uild' },
+      { key = 'c', cmd = 'run -t clean', desc = ' [c]lean' },
+      { key = 'f', cmd = 'run -t fullclean', desc = ' [f]ull clean' },
+      { key = 'd', cmd = 'device list', desc = ' [d]evice list' },
+      { key = 'm', cmd = 'run -t monitor', desc = ' [m]onitor' },
+      { key = 'u', cmd = 'run -t upload', desc = ' [u]pload' },
+      { key = 's', cmd = 'run -t uploadfs', desc = ' upload file [s]ystem' },
+      { key = 't', cmd = '', desc = ' Core CLI [T]erminal' },
+    }},
+    { group = '  [d]ependencies', key = 'd', elements = {
+      { key = 'l', cmd = 'pkg list', desc = ' [l]ist packages' },
+      { key = 'o', cmd = 'pkg outdated', desc = ' List [o]utdated packages' },
+      { key = 'u', cmd = 'pkg update', desc = ' [u]pdate packages' },
+    }},
+    { group = '  [a]dvance', key = 'a', elements = {
+      { key = 't', cmd = 'test', desc = ' [t]est' },
+      { key = 'c', cmd = 'check', desc = ' [c]heck' },
+      { key = 'd', cmd = 'debug', desc = ' [d]ebug' },
+      { key = 'b', cmd = 'run -t compiledb', desc = ' compilation data[b]ase' },
+    }},
+    { group = '  [v]erbose', key = 'av', elements = {
+      { key = 'v', cmd = 'debug', desc = ' [v]erbose' },
+      { key = 'b', cmd = 'run -v', desc = ' [b]uild' },
+      { key = 'd', cmd = 'debug -v', desc = ' [d]ebug' },
+      { key = 'u', cmd = 'run -v -t upload', desc = ' [u]pload' },
+      { key = 's', cmd = 'run -v -t uploadfs', desc = ' upload file [s]ystem' },
+      { key = 't', cmd = 'test -v', desc = ' [t]est' },
+      { key = 'c', cmd = 'check -v', desc = ' [c]heck' },
+      { key = 'a', cmd = 'run -v -t compiledb', desc = ' compilation databa[a]e' },
+    }},
+    { group = '  [r]emote', key = 'r', elements = {
+      { key = 'u', cmd = 'remote run -t upload', desc = ' [u]pload' },
+      { key = 't', cmd = 'remote test', desc = ' [t]est' },
+      { key = 'm', cmd = 'remote run -t monitor', desc = ' [m]onitor' },
+      { key = 'd', cmd = 'remote device list', desc = ' [d]evice list' },
+    }},
+    { group = '  [m]iscellaneous', key = 'm', elements = {
+      { key = 'u', cmd = 'upgrade', desc = ' [u]pgrade' },
+    }},
+  }
+
+}
+```
+
 ### Lazy loading
 
 It's possible to lazy load the plugin using Lazy.nvim, this will load the plugins only when it is needed, to enable lazy loading, add this plugin spec to your config.

--- a/lua/platformio/init.lua
+++ b/lua/platformio/init.lua
@@ -3,6 +3,49 @@ local M = {}
 local default_config = {
   lsp = 'ccls',
   menu_key = nil,
+
+  menu_bindings = {
+    { group = '  [g]eneral', key = 'g', elements = {
+      { key = 'b', cmd = 'run', desc = ' [b]uild' },
+      { key = 'c', cmd = 'run -t clean', desc = ' [c]lean' },
+      { key = 'f', cmd = 'run -t fullclean', desc = ' [f]ull clean' },
+      { key = 'd', cmd = 'device list', desc = ' [d]evice list' },
+      { key = 'm', cmd = 'run -t monitor', desc = ' [m]onitor' },
+      { key = 'u', cmd = 'run -t upload', desc = ' [u]pload' },
+      { key = 's', cmd = 'run -t uploadfs', desc = ' upload file [s]ystem' },
+      { key = 't', cmd = '', desc = ' Core CLI [T]erminal' },
+    }},
+    { group = '  [d]ependencies', key = 'd', elements = {
+      { key = 'l', cmd = 'pkg list', desc = ' [l]ist packages' },
+      { key = 'o', cmd = 'pkg outdated', desc = ' List [o]utdated packages' },
+      { key = 'u', cmd = 'pkg update', desc = ' [u]pdate packages' },
+    }},
+    { group = '  [a]dvance', key = 'a', elements = {
+      { key = 't', cmd = 'test', desc = ' [t]est' },
+      { key = 'c', cmd = 'check', desc = ' [c]heck' },
+      { key = 'd', cmd = 'debug', desc = ' [d]ebug' },
+      { key = 'b', cmd = 'run -t compiledb', desc = ' compilation data[b]ase' },
+    }},
+    { group = '  [v]erbose', key = 'av', elements = {
+      { key = 'v', cmd = 'debug', desc = ' [v]erbose' },
+      { key = 'b', cmd = 'run -v', desc = ' [b]uild' },
+      { key = 'd', cmd = 'debug -v', desc = ' [d]ebug' },
+      { key = 'u', cmd = 'run -v -t upload', desc = ' [u]pload' },
+      { key = 's', cmd = 'run -v -t uploadfs', desc = ' upload file [s]ystem' },
+      { key = 't', cmd = 'test -v', desc = ' [t]est' },
+      { key = 'c', cmd = 'check -v', desc = ' [c]heck' },
+      { key = 'a', cmd = 'run -v -t compiledb', desc = ' compilation databa[a]e' },
+    }},
+    { group = '  [r]emote', key = 'r', elements = {
+      { key = 'u', cmd = 'remote run -t upload', desc = ' [u]pload' },
+      { key = 't', cmd = 'remote test', desc = ' [t]est' },
+      { key = 'm', cmd = 'remote run -t monitor', desc = ' [m]onitor' },
+      { key = 'd', cmd = 'remote device list', desc = ' [d]evice list' },
+    }},
+    { group = '  [m]iscellaneous', key = 'm', elements = {
+      { key = 'u', cmd = 'upgrade', desc = ' [u]pgrade' },
+    }},
+  }
 }
 
 M.config = vim.deepcopy(default_config)
@@ -11,6 +54,7 @@ function M.setup(user_config)
   local valid_keys = {
     lsp = true,
     menu_key = true,
+    menu_bindings = true,
   }
   for key, _ in pairs(user_config or {}) do
     if not valid_keys[key] then

--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -1,9 +1,12 @@
 local M = {}
 
 function M.piomenu(config)
-  if config.menu_key == nil then
-     return 
+
+
+  if config.menu_key == nil or config.menu_bindings == nil then
+    return
   end
+
   local key = vim.api.nvim_replace_termcodes(config.menu_key, true, true, true)
   local mapping = vim.fn.mapcheck(key, "")
   if mapping ~= "" then
@@ -12,61 +15,38 @@ function M.piomenu(config)
     return
   end
 
-  local ok, wk = pcall(require, 'which-key') --will also load the package if it isn't loaded already
+  local ok, wk = pcall(require, 'which-key')
   if not ok then
-    vim.api.nvim_echo({
-      { 'which-key plugin not found!', 'ErrorMsg' },
-    }, true, {})
-  else
-    local prefix = config.menu_key  -- or use 'gp'
-    local Piocmd = 'Piocmdf'   -- 'Piocmdh' (horizontal terminal)  'Piocmdf' (float terminal)
-    wk.add({
-      { prefix, group = ' PlatformIO:' },
-      { prefix .. 'g', group = '  [g]eneral' },
-      { prefix .. 'd', group = '  [d]ependencies' },
-      { prefix .. 'a', group = '  [a]dvance' },
-      { prefix .. 'av', group = '  [v]erbose' },
-      { prefix .. 'r', group = '  [r]emote' },
-      { prefix .. 'm', group = '  [m]iscellaneous' },
-      {
-        mode = { 'n' }, -- NORMAL mode
-        { prefix .. 'l', '<cmd>' .. 'PioTermList' .. ' <CR>', desc = ' Pio Terminals [l]ist' },
-        { prefix .. 'gb', '<cmd>' .. Piocmd .. ' run<CR>', desc = ' [b]uild' },
-        { prefix .. 'gc', '<cmd>' .. Piocmd .. ' run -t clean<CR>', desc = ' [c]lean' },
-        { prefix .. 'gf', '<cmd>' .. Piocmd .. ' run -t fullclean<CR>', desc = ' [f]ull clean' },
-        { prefix .. 'gd', '<cmd>' .. Piocmd .. ' device list<CR>', desc = ' [d]evice list' },
-        { prefix .. 'gm', '<cmd>' .. 'Piocmdh' .. ' run -t monitor<CR>', desc = ' [m]onitor' },
-        { prefix .. 'gu', '<cmd>' .. Piocmd .. ' run -t upload<CR>', desc = ' [u]pload' },
-        { prefix .. 'gs', '<cmd>' .. Piocmd .. ' run -t uploadfs<CR>', desc = ' upload file [s]ystem' },
-        { prefix .. 'gt', '<cmd>' .. Piocmd .. '<CR>', desc = ' Core CLI [T]erminal' },
-    
-        { prefix .. 'dl', '<cmd>' .. Piocmd .. ' pkg list<CR>', desc = ' [l]ist packages' },
-        { prefix .. 'do', '<cmd>' .. Piocmd .. ' pkg outdated<CR>', desc = ' List [o]utdated packages' },
-        { prefix .. 'du', '<cmd>' .. Piocmd .. ' pkg update<CR>', desc = ' [u]pdate packages' },
-    
-        { prefix .. 'at', '<cmd>' .. Piocmd .. ' test<CR>', desc = ' [t]est' },
-        { prefix .. 'ac', '<cmd>' .. Piocmd .. ' check<CR>', desc = ' [c]heck' },
-        { prefix .. 'ad', '<cmd>' .. Piocmd .. ' debug<CR>', desc = ' [d]ebug' },
-        { prefix .. 'ab', '<cmd>' .. Piocmd .. ' run -t compiledb<CR>', desc = ' compilation data[b]ase' },
-    
-        { prefix .. 'av', '<cmd>' .. Piocmd .. ' debug<CR>', desc = ' [v]erbose' },
-        { prefix .. 'avb', '<cmd>' .. Piocmd .. ' run -v<CR>', desc = ' [b]uild' },
-        { prefix .. 'avd', '<cmd>' .. Piocmd .. ' debug -v<CR>', desc = ' [d]ebug' },
-        { prefix .. 'avu', '<cmd>' .. Piocmd .. ' run -v -t upload<CR>', desc = ' [u]pload' },
-        { prefix .. 'avs', '<cmd>' .. Piocmd .. ' run -v -t uploadfs<CR>', desc = ' upload file [s]ystem' },
-        { prefix .. 'avt', '<cmd>' .. Piocmd .. ' test -v<CR>', desc = ' [t]est' },
-        { prefix .. 'avc', '<cmd>' .. Piocmd .. ' check -v<CR>', desc = ' [c]heck' },
-        { prefix .. 'ava', '<cmd>' .. Piocmd .. ' run -v -t compiledb<CR>', desc = ' compilation databa[a]e' },
-    
-        { prefix .. 'ru', '<cmd>' .. Piocmd .. ' remote run -t upload<CR>', desc = ' [u]pload' },
-        { prefix .. 'rt', '<cmd>' .. Piocmd .. ' remote test<CR>', desc = ' [t]est' },
-        { prefix .. 'rm', '<cmd>' .. 'Piocmdh' .. ' remote run -t monitor<CR>', desc = ' [m]onitor' },
-        { prefix .. 'rd', '<cmd>' .. Piocmd .. ' remote device list<CR>', desc = ' [d]evice list' },
-    
-        { prefix .. 'mu', '<cmd>' .. Piocmd .. ' upgrade<CR>', desc = ' [u]pgrade' },
-      },
-    })
+    vim.api.nvim_echo({ { 'which-key plugin not found!', 'ErrorMsg' } }, true, {})
+    return
   end
+
+  local prefix = config.menu_key
+  local Piocmd = config.piocmd or 'Piocmdf'
+
+  local wk_table = {}
+
+  -- Top level group
+  table.insert(wk_table, { prefix, group = ' PlatformIO:' })
+
+  -- Group headers
+  for _, group in ipairs(config.menu_bindings) do
+    table.insert(wk_table, { prefix .. group.key, group = group.group })
+  end
+
+  -- Key mappings
+  local commands = { mode = { 'n' } }
+  for _, group in ipairs(config.menu_bindings) do
+    for _, item in ipairs(group.elements) do
+      local full_key = prefix .. group.key .. item.key
+      local full_cmd = '<cmd>' .. (item.cmd:find('^Pio') and item.cmd or (Piocmd .. ' ' .. item.cmd)) .. '<CR>'
+      table.insert(commands, { full_key, full_cmd, desc = item.desc })
+    end
+  end
+
+  table.insert(wk_table, commands)
+
+  wk.add(wk_table)
 end
 
 return M


### PR DESCRIPTION
### Following are the default keybindings, you can overwrite them in the config
```lua
require('platformio').setup({

  menu_bindings = {
    { group = '  [g]eneral', key = 'g', elements = {
      { key = 'b', cmd = 'run', desc = ' [b]uild' },
      { key = 'c', cmd = 'run -t clean', desc = ' [c]lean' },
      { key = 'f', cmd = 'run -t fullclean', desc = ' [f]ull clean' },
      { key = 'd', cmd = 'device list', desc = ' [d]evice list' },
      { key = 'm', cmd = 'run -t monitor', desc = ' [m]onitor' },
      { key = 'u', cmd = 'run -t upload', desc = ' [u]pload' },
      { key = 's', cmd = 'run -t uploadfs', desc = ' upload file [s]ystem' },
      { key = 't', cmd = '', desc = ' Core CLI [T]erminal' },
    }},
    { group = '  [d]ependencies', key = 'd', elements = {
      { key = 'l', cmd = 'pkg list', desc = ' [l]ist packages' },
      { key = 'o', cmd = 'pkg outdated', desc = ' List [o]utdated packages' },
      { key = 'u', cmd = 'pkg update', desc = ' [u]pdate packages' },
    }},
    { group = '  [a]dvance', key = 'a', elements = {
      { key = 't', cmd = 'test', desc = ' [t]est' },
      { key = 'c', cmd = 'check', desc = ' [c]heck' },
      { key = 'd', cmd = 'debug', desc = ' [d]ebug' },
      { key = 'b', cmd = 'run -t compiledb', desc = ' compilation data[b]ase' },
    }},
    { group = '  [v]erbose', key = 'av', elements = {
      { key = 'v', cmd = 'debug', desc = ' [v]erbose' },
      { key = 'b', cmd = 'run -v', desc = ' [b]uild' },
      { key = 'd', cmd = 'debug -v', desc = ' [d]ebug' },
      { key = 'u', cmd = 'run -v -t upload', desc = ' [u]pload' },
      { key = 's', cmd = 'run -v -t uploadfs', desc = ' upload file [s]ystem' },
      { key = 't', cmd = 'test -v', desc = ' [t]est' },
      { key = 'c', cmd = 'check -v', desc = ' [c]heck' },
      { key = 'a', cmd = 'run -v -t compiledb', desc = ' compilation databa[a]e' },
    }},
    { group = '  [r]emote', key = 'r', elements = {
      { key = 'u', cmd = 'remote run -t upload', desc = ' [u]pload' },
      { key = 't', cmd = 'remote test', desc = ' [t]est' },
      { key = 'm', cmd = 'remote run -t monitor', desc = ' [m]onitor' },
      { key = 'd', cmd = 'remote device list', desc = ' [d]evice list' },
    }},
    { group = '  [m]iscellaneous', key = 'm', elements = {
      { key = 'u', cmd = 'upgrade', desc = ' [u]pgrade' },
    }},
  }

}
```
