### PR TITLE
update; if pio terminal (mon or cli) perviously created, then before re-open, reassign its display name with the new orig-window

### DIFF
--- a/lua/platformio/utils.lua
+++ b/lua/platformio/utils.lua
@@ -135,6 +135,7 @@ function M.ToggleTerminal(command, direction, resetLSP)
 
   if string.find(command, ' monitor') then
     if prev.mon then -- INFO: if previous monitor terminal already opened ==> reopen
+      prev.mon.display_name = 'piomon:' .. orig_window
       local win_type = vim.fn.win_gettype(prev.mon.window)
       local win_open = win_type == '' or win_type == 'popup'
       if prev.mon.window and (win_open and vim.api.nvim_win_get_buf(prev.mon.window) == prev.mon.bufnr) then
@@ -148,18 +149,7 @@ function M.ToggleTerminal(command, direction, resetLSP)
     pioOpts.display_name = 'piomon:' .. orig_window
   else -- INFO: if previous cli terminal already opened ==> reopen
     if prev.cli then
-      prev.cli.on_close = function(t)
-        local ow = tonumber(M.strsplit(t.display_name, ':')[2])
-        if ow and vim.api.nvim_win_is_valid(ow) then
-          vim.api.nvim_set_current_win(ow)
-        else
-          vim.api.nvim_set_current_win(0)
-        end
-        if resetLSP then
-          vim.cmd(':PioLSP')
-        end
-      end
-
+      prev.cli.display_name = 'piocli:' .. orig_window
       local win_type = vim.fn.win_gettype(prev.cli.window)
       local win_open = win_type == '' or win_type == 'popup'
       if prev.cli.window and (win_open and vim.api.nvim_win_get_buf(prev.cli.window) == prev.cli.bufnr) then


### PR DESCRIPTION
update; 
if pio terminal (mon or cli) previously created, then before reopen or reuse, reassign its display_name with the new orig-window.
so when terminal closed, focus will go the previous window.

no need to re-assign on_close() as it was already assigned the first time the terminal (mon or cli) was created. 