### PR TITLE
Fix space in library path

### DIFF
--- a/lua/platformio/piolsp.lua
+++ b/lua/platformio/piolsp.lua
@@ -13,6 +13,7 @@ local function escape_flags(flags)
     -- Escape parentheses (common in include paths)
     escaped = escaped:gsub('%(', '\\(')
     escaped = escaped:gsub('%)', '\\)')
+    escaped = escaped:gsub('%s+', '\\ ')
     table.insert(escaped_flags, escaped)
   end
 


### PR DESCRIPTION
Thanks for your plugin ^^

BTW I have a bug with one library which have space in its path : `Adafruit SSD1306`  and other ` Adafruit`  libraries.
Thus, the header file `Adafruit_SSD1306.h`  is not found and I have an error just in my editor.

I'm using `clangd`  has LSP and ` ccls`  has source.

Here is my wrokaround.
The path is good but lots of other values with space likes definitions have multiple blackslash.
It seems not a real problem for the LSP as I have seen. 