### PR TITLE
Remove which-key plugin setup

### DIFF
--- a/lua/platformio/piomenu.lua
+++ b/lua/platformio/piomenu.lua
@@ -30,9 +30,6 @@ function M.piomenu(config)
     return
   end
 
-  wk.setup({
-    preset = 'helix', --'modern', --'classic'
-  })
   local Config = require('which-key.config')
   Config.sort = { 'order', 'group', 'manual', 'mod' }
 


### PR DESCRIPTION
I'm using `Astronvim`  to configuration my nvim and this hardcoded value bother me.
I did not find an easy solution to get ride of it ^;

I propose to remove it completly but you can also provide this as a configuration value.