### PR TITLE
fix: add none option and prevent error when framework is unselected

### DIFF
--- a/lua/platformio/pioinit.lua
+++ b/lua/platformio/pioinit.lua
@@ -1,32 +1,33 @@
 local M = {}
 
-local pickers = require 'telescope.pickers'
-local finders = require 'telescope.finders'
+local pickers = require('telescope.pickers')
+local finders = require('telescope.finders')
 local telescope_conf = require('telescope.config').values
-local actions = require 'telescope.actions'
-local action_state = require 'telescope.actions.state'
-local entry_display = require 'telescope.pickers.entry_display'
-local make_entry = require 'telescope.make_entry'
-local utils = require 'platformio.utils'
-local previewers = require 'telescope.previewers'
+local actions = require('telescope.actions')
+local action_state = require('telescope.actions.state')
+local entry_display = require('telescope.pickers.entry_display')
+local make_entry = require('telescope.make_entry')
+local utils = require('platformio.utils')
+local previewers = require('telescope.previewers')
 local config = require('platformio').config
+local boilerplate_gen = require('platformio.boilerplate').boilerplate_gen
 
 local boardentry_maker = function(opts)
-  local displayer = entry_display.create {
+  local displayer = entry_display.create({
     separator = '▏',
     items = {
       { width = 35 },
       { width = 20 },
       { width = 15 },
     },
-  }
+  })
 
   local make_display = function(entry)
-    return displayer {
+    return displayer({
       entry.value.name,
       entry.value.vendor,
       entry.value.platform,
-    }
+    })
   end
 
   return function(entry)
@@ -49,9 +50,9 @@ local function pick_framework(board_details)
   pickers
     .new(opts, {
       prompt_title = 'frameworks',
-      finder = finders.new_table {
+      finder = finders.new_table({
         results = vim.list_extend({"none"}, board_details['frameworks']),
-      },
+      }),
       attach_mappings = function(prompt_bufnr, _)
         actions.select_default:replace(function()
           actions.close(prompt_bufnr)
@@ -60,14 +61,12 @@ local function pick_framework(board_details)
 	  if selected_framework == "none" then
 		  selected_framework = ""
 	  end
-          local command = 'pio project init --ide=vim --board '
-            .. board_details['id']
-            .. ' --project-option "framework='
-            .. selected_framework
-            .. '"'
-            .. (config.lsp == 'clangd' and ' && pio run -t compiledb ' or '')
-            -- .. utils.extra
-          utils.ToggleTerminal(command, 'float')
+          local command = 'pio project init --board ' .. board_details['id'] .. ' --project-option "framework=' .. selected_framework .. '"'
+          -- .. utils.extra
+          utils.ToggleTerminal(command, 'float', function()
+            vim.cmd(':PioLSP')
+            boilerplate_gen(selected_framework)
+          end)
         end)
         return true
       end,
@@ -81,10 +80,10 @@ local function pick_board(json_data)
   pickers
     .new(opts, {
       prompt_title = 'Boards',
-      finder = finders.new_table {
+      finder = finders.new_table({
         results = json_data,
         entry_maker = opts.entry_maker or boardentry_maker(opts),
-      },
+      }),
       attach_mappings = function(prompt_bufnr, _)
         actions.select_default:replace(function()
           actions.close(prompt_bufnr)
@@ -93,7 +92,7 @@ local function pick_board(json_data)
         end)
         return true
       end,
-      previewer = previewers.new_buffer_previewer {
+      previewer = previewers.new_buffer_previewer({
         title = 'Board Info',
         define_preview = function(self, entry, _)
           local json = utils.strsplit(vim.inspect(entry['value']['data']), '\n')
@@ -107,7 +106,7 @@ local function pick_board(json_data)
             vim.api.nvim_set_option_value('wrapmargin', 2, { buf = bufnr })
           end, 0)
         end,
-      },
+      }),
       sorter = telescope_conf.generic_sorter(opts),
     })
     :find()
@@ -124,7 +123,7 @@ function M.pioinit()
   if not handel then
     return
   end
-  local json_str = handel:read '*a'
+  local json_str = handel:read('*a')
   handel:close()
 
   if #json_str == 0 then
@@ -133,7 +132,7 @@ function M.pioinit()
     if not handel then
       return
     end
-    local command_output = handel:read '*a'
+    local command_output = handel:read('*a')
     handel:close()
     vim.notify('Some error occured while executing `' .. command .. "`', command output: \n", vim.log.levels.WARN)
     print(command_output)

--- a/lua/platformio/pioinit.lua
+++ b/lua/platformio/pioinit.lua
@@ -1,33 +1,32 @@
 local M = {}
 
-local pickers = require('telescope.pickers')
-local finders = require('telescope.finders')
+local pickers = require 'telescope.pickers'
+local finders = require 'telescope.finders'
 local telescope_conf = require('telescope.config').values
-local actions = require('telescope.actions')
-local action_state = require('telescope.actions.state')
-local entry_display = require('telescope.pickers.entry_display')
-local make_entry = require('telescope.make_entry')
-local utils = require('platformio.utils')
-local previewers = require('telescope.previewers')
+local actions = require 'telescope.actions'
+local action_state = require 'telescope.actions.state'
+local entry_display = require 'telescope.pickers.entry_display'
+local make_entry = require 'telescope.make_entry'
+local utils = require 'platformio.utils'
+local previewers = require 'telescope.previewers'
 local config = require('platformio').config
-local boilerplate_gen = require('platformio.boilerplate').boilerplate_gen
 
 local boardentry_maker = function(opts)
-  local displayer = entry_display.create({
+  local displayer = entry_display.create {
     separator = '▏',
     items = {
       { width = 35 },
       { width = 20 },
       { width = 15 },
     },
-  })
+  }
 
   local make_display = function(entry)
-    return displayer({
+    return displayer {
       entry.value.name,
       entry.value.vendor,
       entry.value.platform,
-    })
+    }
   end
 
   return function(entry)
@@ -50,20 +49,25 @@ local function pick_framework(board_details)
   pickers
     .new(opts, {
       prompt_title = 'frameworks',
-      finder = finders.new_table({
-        results = board_details['frameworks'],
-      }),
+      finder = finders.new_table {
+        results = vim.list_extend({"none"}, board_details['frameworks']),
+      },
       attach_mappings = function(prompt_bufnr, _)
         actions.select_default:replace(function()
           actions.close(prompt_bufnr)
           local selection = action_state.get_selected_entry()
           local selected_framework = selection[1]
-          local command = 'pio project init --board ' .. board_details['id'] .. ' --project-option "framework=' .. selected_framework .. '"'
-          -- .. utils.extra
-          utils.ToggleTerminal(command, 'float', function()
-            vim.cmd(':PioLSP')
-            boilerplate_gen(selected_framework)
-          end)
+	  if selected_framework == "none" then
+		  selected_framework = ""
+	  end
+          local command = 'pio project init --ide=vim --board '
+            .. board_details['id']
+            .. ' --project-option "framework='
+            .. selected_framework
+            .. '"'
+            .. (config.lsp == 'clangd' and ' && pio run -t compiledb ' or '')
+            -- .. utils.extra
+          utils.ToggleTerminal(command, 'float')
         end)
         return true
       end,
@@ -77,10 +81,10 @@ local function pick_board(json_data)
   pickers
     .new(opts, {
       prompt_title = 'Boards',
-      finder = finders.new_table({
+      finder = finders.new_table {
         results = json_data,
         entry_maker = opts.entry_maker or boardentry_maker(opts),
-      }),
+      },
       attach_mappings = function(prompt_bufnr, _)
         actions.select_default:replace(function()
           actions.close(prompt_bufnr)
@@ -89,7 +93,7 @@ local function pick_board(json_data)
         end)
         return true
       end,
-      previewer = previewers.new_buffer_previewer({
+      previewer = previewers.new_buffer_previewer {
         title = 'Board Info',
         define_preview = function(self, entry, _)
           local json = utils.strsplit(vim.inspect(entry['value']['data']), '\n')
@@ -103,7 +107,7 @@ local function pick_board(json_data)
             vim.api.nvim_set_option_value('wrapmargin', 2, { buf = bufnr })
           end, 0)
         end,
-      }),
+      },
       sorter = telescope_conf.generic_sorter(opts),
     })
     :find()
@@ -120,7 +124,7 @@ function M.pioinit()
   if not handel then
     return
   end
-  local json_str = handel:read('*a')
+  local json_str = handel:read '*a'
   handel:close()
 
   if #json_str == 0 then
@@ -129,7 +133,7 @@ function M.pioinit()
     if not handel then
       return
     end
-    local command_output = handel:read('*a')
+    local command_output = handel:read '*a'
     handel:close()
     vim.notify('Some error occured while executing `' .. command .. "`', command output: \n", vim.log.levels.WARN)
     print(command_output)


### PR DESCRIPTION
Greetings, this is a great project as I am currently learning embedded development. However, I found that when using `pioinit` and selecting a board without a framework (e.g., AT89S52), it throws a nil error and fails to initialize the project. I added a `"none"` option to fix this, which sets the framework to empty.