### PR TITLE
fix: Remove cd side effect when executing pio commands

### DIFF
--- a/lua/platformio/piocmd.lua
+++ b/lua/platformio/piocmd.lua
@@ -6,16 +6,14 @@ function M.piocmd(cmd_table, direction)
     return
   end
 
-  utils.cd_pioini()
-
   if cmd_table[1] == '' then
-    utils.ToggleTerminal('', direction)
+    utils.ToggleTerminal('', direction, nil, utils.get_platformioRootDir())
   else
     local cmd = 'pio '
     for _, v in pairs(cmd_table) do
       cmd = cmd .. ' ' .. v
     end
-    utils.ToggleTerminal(cmd, direction)
+    utils.ToggleTerminal(cmd, direction, nil, utils.get_platformioRootDir())
   end
 end
 

--- a/lua/platformio/piodebug.lua
+++ b/lua/platformio/piodebug.lua
@@ -6,11 +6,9 @@ function M.piodebug(args_table)
     return
   end
 
-  utils.cd_pioini()
-
   local command = 'pio debug --interface=gdb -- -x .pioinit'
   -- local command = string.format('pio debug --interface=gdb -- -x .pioinit %s', utils.extra)
-  utils.ToggleTerminal(command, 'float')
+  utils.ToggleTerminal(command, 'float', nil, utils.get_platformioRootDir())
 end
 
 return M

--- a/lua/platformio/piolib.lua
+++ b/lua/platformio/piolib.lua
@@ -42,7 +42,7 @@ function M.piolib(lib_arg_list)
       local command = 'pio pkg install --library "' .. pkg_name .. '"'
       utils.ToggleTerminal(command, 'float', function()
         vim.cmd(':PioLSP')
-      end)
+      end, utils.get_platformioRootDir())
     end)
   else
     vim.notify(

--- a/lua/platformio/piolsp.lua
+++ b/lua/platformio/piolsp.lua
@@ -106,13 +106,12 @@ function M.piolsp()
   if not utils.pio_install_check() then
     return
   end
-  utils.cd_pioini()
 
   if config.lsp == 'clangd' and config.clangd_source == 'compiledb' then
-    utils.shell_cmd_blocking('pio run -t compiledb')
+    utils.shell_cmd_blocking({ 'pio', 'run', '-t', 'compiledb' }, utils.get_platformioRootDir())
     gitignore_lsp_configs('compile_commands.json')
   else
-    utils.shell_cmd_blocking('pio project init --ide=vim')
+    utils.shell_cmd_blocking({ 'pio', 'project', 'init', '--ide=vim' }, utils.get_platformioRootDir())
 
     if config.lsp == 'clangd' then
       M.gen_clangd_config()

--- a/lua/platformio/piomon.lua
+++ b/lua/platformio/piomon.lua
@@ -6,8 +6,6 @@ function M.piomon(args_table)
     return
   end
 
-  utils.cd_pioini()
-
   local command = nil
   if #args_table == 0 then
     command = 'pio device monitor'
@@ -23,7 +21,7 @@ function M.piomon(args_table)
   if command == nil then
     vim.notify('Usage: Piomon <baud> <port>', vim.log.levels.ERROR)
   else
-    utils.ToggleTerminal(command, 'horizontal')
+    utils.ToggleTerminal(command, 'horizontal', nil, utils.get_platformioRootDir())
   end
 end
 

--- a/lua/platformio/piorun.lua
+++ b/lua/platformio/piorun.lua
@@ -3,27 +3,23 @@ local M = {}
 local utils = require('platformio.utils')
 
 function M.piobuild()
-  utils.cd_pioini()
   local command = 'pio run' -- .. utils.extra
-  utils.ToggleTerminal(command, 'float')
+  utils.ToggleTerminal(command, 'float', nil, utils.get_platformioRootDir())
 end
 
 function M.pioupload()
-  utils.cd_pioini()
   local command = 'pio run --target upload' -- .. utils.extra
-  utils.ToggleTerminal(command, 'float')
+  utils.ToggleTerminal(command, 'float', nil, utils.get_platformioRootDir())
 end
 
 function M.piouploadfs()
-  utils.cd_pioini()
   local command = 'pio run --target uploadfs' -- .. utils.extra
-  utils.ToggleTerminal(command, 'float')
+  utils.ToggleTerminal(command, 'float', nil, utils.get_platformioRootDir())
 end
 
 function M.pioclean()
-  utils.cd_pioini()
   local command = 'pio run --target clean' -- .. utils.extra
-  utils.ToggleTerminal(command, 'float')
+  utils.ToggleTerminal(command, 'float', nil, utils.get_platformioRootDir())
 end
 
 function M.piorun(arg_table)

--- a/lua/platformio/utils.lua
+++ b/lua/platformio/utils.lua
@@ -19,10 +19,6 @@ function M.check_prefix(str, prefix)
   return str:sub(1, #prefix) == prefix
 end
 
-local function pathmul(n)
-  return '..' .. string.rep('/..', n)
-end
-
 ------------------------------------------------------
 local is_windows = jit.os == 'Windows'
 
@@ -115,7 +111,7 @@ end
 
 ------------------------------------------------------
 -- INFO: ToggleTerminal
-function M.ToggleTerminal(command, direction, exit_callback)
+function M.ToggleTerminal(command, direction, exit_callback, working_dir)
   if type(exit_callback) ~= 'function' then
     exit_callback = function() end
   end
@@ -128,6 +124,8 @@ function M.ToggleTerminal(command, direction, exit_callback)
 
   local title = ''
   local pioOpts = {}
+
+  pioOpts.dir = working_dir or vim.fn.getcwd()
 
   -- INFO: set orig_window to current window, or if available get current toggleterm previous window
   local prev = getPreviousWindow(vim.api.nvim_get_current_win())
@@ -320,8 +318,6 @@ end
 
 ----------------------------------------------------------------------------------------
 
-local paths = { '.', '..', pathmul(1), pathmul(2), pathmul(3), pathmul(4), pathmul(5) }
-
 function M.file_exists(name)
   local f = io.open(name, 'r')
   if f ~= nil then
@@ -332,22 +328,22 @@ function M.file_exists(name)
   end
 end
 
-function M.set_platformioRootDir()
-  if vim.g.platformioRootDir ~= nil then
-    return
-  end
-  for _, path in pairs(paths) do
-    if M.file_exists(path .. '/platformio.ini') then
-      vim.g.platformioRootDir = path
-      return
+function M.get_platformioRootDir()
+  if vim.g.platformioRootDir == nil then
+    local path = vim.api.nvim_buf_get_name(0)
+    if path == '' then
+      path = vim.fn.getcwd()
+    end
+    local match = vim.fs.find({ 'platformio.ini' }, { upward = true, path = path })
+    if #match > 0 then
+      vim.g.platformioRootDir = vim.fs.dirname(match[1])
+    end
+
+    if vim.g.platformioRootDir == nil then
+      vim.notify('Could not find platformio.ini, run :Pioinit to create a new project', vim.log.levels.ERROR)
     end
   end
-  vim.notify('Could not find platformio.ini, run :Pioinit to create a new project', vim.log.levels.ERROR)
-end
-
-function M.cd_pioini()
-  M.set_platformioRootDir()
-  vim.cmd('cd ' .. vim.g.platformioRootDir)
+  return vim.g.platformioRootDir
 end
 
 function M.pio_install_check()
@@ -385,16 +381,32 @@ function M.async_shell_cmd(cmd, callback)
   })
 end
 
-function M.shell_cmd_blocking(command)
-  local handle = io.popen(command, 'r')
-  if not handle then
-    return nil, 'failed to run command'
+function M.shell_cmd_blocking(args, working_dir)
+  if vim.system then
+    local ok, res = pcall(function()
+      return vim.system(args, { cwd = working_dir, text = true }):wait()
+    end)
+    if not ok then
+      return nil, 'failed to spawn command: ' .. tostring(res)
+    end
+    return res.stdout
+  else
+    -- Fallback for Neovim < 0.10.0 using vim.fn.system
+    local cmd_str = table.concat(args, ' ')
+    local old_dir = nil
+    if working_dir then
+      old_dir = vim.fn.getcwd()
+      vim.cmd('cd ' .. vim.fn.fnameescape(working_dir))
+    end
+
+    local stdout = vim.fn.system(cmd_str)
+
+    if old_dir then
+      vim.cmd('cd ' .. vim.fn.fnameescape(old_dir))
+    end
+
+    return stdout
   end
-
-  local result = handle:read('*a')
-  handle:close()
-
-  return result
 end
 
 return M


### PR DESCRIPTION
Right now, whenever the plugin wants to execute pio commands, cd is performed to move nvim to the project's root. This is not a good approach because it moves the current directory without the user's consent, which affects subsequent terminal spawns and most importantly, things like telescope search.

This change ensures pio commands executed do not affect the global current working directory. I've also improved the project root lookup function to not rely on hardcoded constants.